### PR TITLE
fix: lazily build eval script to avoid empty registry

### DIFF
--- a/src/sidebar/hooks/useSelectedElement.ts
+++ b/src/sidebar/hooks/useSelectedElement.ts
@@ -7,9 +7,9 @@ export type AnalysisStatus = 'no-selection' | 'analyzing' | 'ready' | 'error';
 
 export { isElementData };
 
-/** Runs in the inspected page's context via eval(). Uses var for broad compat. */
-const EVAL_SCRIPT = `
-(function() {
+/** Builds the eval script lazily so the registry is guaranteed to be populated. */
+function buildEvalScript(): string {
+  return `(function() {
   var el = $0;
   if (!el) return null;
   var cs = getComputedStyle(el);
@@ -21,8 +21,13 @@ const EVAL_SCRIPT = `
         ${generateStyleExtractFragment()}
     }
   };
-})()
-`;
+})()`;
+}
+
+let cachedEvalScript: string | undefined;
+function getEvalScript(): string {
+  return (cachedEvalScript ??= buildEvalScript());
+}
 
 const DEBOUNCE_MS = 150;
 
@@ -35,7 +40,7 @@ export function useSelectedElement() {
     const requestId = requestIdRef.current + 1;
     requestIdRef.current = requestId;
     setStatus('analyzing');
-    chrome.devtools.inspectedWindow.eval(EVAL_SCRIPT, (result: unknown, exceptionInfo) => {
+    chrome.devtools.inspectedWindow.eval(getEvalScript(), (result: unknown, exceptionInfo) => {
       // Ignore stale eval callbacks from older selections.
       if (requestId !== requestIdRef.current) return;
 


### PR DESCRIPTION
## Summary

- `EVAL_SCRIPT` was built as a module-level constant, which ran `generateStyleExtractFragment()` before rule side-effect imports populated the registry
- This caused `computedStyles` to be an empty object, failing `isElementData()` validation and showing "Error" status in the sidebar
- Changed to lazy construction with `??=` caching — the eval script is built on first `evaluate()` call when all rules are guaranteed to be registered

## Test plan

- [ ] Open DevTools on `examples/test.html`, select an element — status should show "Ready" instead of "Error"
- [ ] Verify warnings appear correctly for noop CSS properties
- [ ] `pnpm build` passes
- [ ] `pnpm test` passes (67 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)