### PR TITLE
feat: add flex-no-container-props rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Pure-function rules with zero Chrome API dependency — fully testable:
 - `order.ts` — `item-no-order`: order on non-flex/grid items
 - `block-vertical-align.ts` — `block-no-vertical-align`: vertical-align on block-level elements
 - `static-z-index.ts` — `static-no-z-index`: z-index on non-stacking-context elements
+- `flex-container-props.ts` — `flex-no-container-props`: flex-direction/flex-wrap on non-flex containers
 - `__tests__/` — tests covering all rules + engine integration
 
 #### Rule ID Naming Convention
@@ -65,12 +66,13 @@ Rule IDs follow Stylelint's `thing-no-qualifier` pattern — the de facto standa
 | `inline-no-dimensions`    | inline non-replaced elements  | width/height                |
 | `container-no-gap`        | non-flex/grid containers      | gap properties              |
 | `container-no-align`      | non-flex/grid containers      | align-items/justify-content |
-| `container-no-place`      | non-flex/grid containers      | place-content               |
+| `container-no-place`      | non-flex/grid containers      | place-content/place-items   |
 | `static-no-offset`        | static-positioned elements    | top/right/bottom/left       |
 | `item-no-self-align`      | non-flex/grid items           | align-self                  |
 | `item-no-order`           | non-flex/grid items           | order                       |
 | `block-no-vertical-align` | block-level elements          | vertical-align              |
 | `static-no-z-index`       | non-stacking-context elements | z-index                     |
+| `flex-no-container-props` | non-flex containers           | flex-direction/flex-wrap    |
 
 When adding a new rule, pick a descriptive `target` and `qualifier` — avoid numbered IDs like `D-1` or `C-2`.
 

--- a/examples/test.html
+++ b/examples/test.html
@@ -239,6 +239,75 @@
       </div>
     </div>
 
+    <!-- ===== flex-no-container-props: flex-direction/wrap on non-flex ===== -->
+    <h2>flex-no-container-props: flex-direction/wrap on non-flex elements</h2>
+
+    <h3>Should warn</h3>
+    <div class="case expect-warn">
+      <div class="label label-warn">flex-no-container-props warn: block with flex-direction</div>
+      <div style="flex-direction: column">
+        <div>Child 1</div>
+        <div>Child 2</div>
+      </div>
+    </div>
+    <div class="case expect-warn">
+      <div class="label label-warn">flex-no-container-props warn: block with flex-wrap</div>
+      <div style="flex-wrap: wrap">
+        <div>Child 1</div>
+        <div>Child 2</div>
+      </div>
+    </div>
+    <div class="case expect-warn">
+      <div class="label label-warn">
+        flex-no-container-props warn: block with flex-flow shorthand
+      </div>
+      <div style="flex-flow: column wrap">
+        <div>Child 1</div>
+        <div>Child 2</div>
+      </div>
+    </div>
+
+    <h3>Should NOT warn</h3>
+    <div class="case expect-ok">
+      <div class="label label-ok">
+        flex-no-container-props ok: flex container with flex-direction
+      </div>
+      <div style="display: flex; flex-direction: column">
+        <div>Flex child 1</div>
+        <div>Flex child 2</div>
+      </div>
+    </div>
+    <div class="case expect-ok">
+      <div class="label label-ok">flex-no-container-props ok: inline-flex with flex-wrap</div>
+      <span style="display: inline-flex; flex-wrap: wrap">
+        <span>Child 1</span>
+        <span>Child 2</span>
+      </span>
+    </div>
+    <div class="case expect-ok">
+      <div class="label label-ok">
+        flex-no-container-props ok: grid container (no false positive)
+      </div>
+      <div style="display: grid; flex-direction: column; grid-template-columns: 1fr 1fr">
+        <div>Grid child 1</div>
+        <div>Grid child 2</div>
+      </div>
+    </div>
+    <div class="case expect-ok">
+      <div class="label label-ok">flex-no-container-props ok: default values (no override)</div>
+      <div>
+        <div>Plain block element (flex-direction defaults to row)</div>
+      </div>
+    </div>
+    <div class="case expect-ok">
+      <div class="label label-ok">flex-no-container-props ok: display:contents skipped</div>
+      <div style="display: flex">
+        <div style="display: contents; flex-direction: column">
+          <div>Child of contents wrapper</div>
+        </div>
+      </div>
+    </div>
+
     <!-- ===== static-no-offset: offsets on static position ===== -->
     <h2>static-no-offset: top/right/bottom/left on static elements</h2>
 

--- a/src/rules/__tests__/engine.test.ts
+++ b/src/rules/__tests__/engine.test.ts
@@ -43,6 +43,8 @@ function makeElement(
       mixBlendMode: 'normal',
       contain: 'none',
       willChange: 'auto',
+      flexDirection: 'row',
+      flexWrap: 'nowrap',
       ...styles,
     },
     parent: null,
@@ -82,6 +84,12 @@ describe('analyzeElement (integration)', () => {
     const warnings = analyzeElement(makeElement({ verticalAlign: 'middle' }));
     const ruleIds = warnings.map((w) => w.ruleId);
     expect(ruleIds).toContain('block-no-vertical-align');
+  });
+
+  it('detects flex-direction on non-flex container', () => {
+    const warnings = analyzeElement(makeElement({ flexDirection: 'column' }));
+    const ruleIds = warnings.map((w) => w.ruleId);
+    expect(ruleIds).toContain('flex-no-container-props');
   });
 
   it('combines D-1 with other rules on inline element', () => {

--- a/src/rules/__tests__/flex-container-props.test.ts
+++ b/src/rules/__tests__/flex-container-props.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import { checkFlexContainerProps } from '../flex-container-props.ts';
+import { createRuleContext } from '../context.ts';
+import type { ElementData } from '../types.ts';
+
+function makeElement(overrides: Partial<ElementData['computedStyles']>): ElementData {
+  return {
+    tagName: 'div',
+    id: '',
+    classList: [],
+    computedStyles: {
+      display: 'block',
+      width: 'auto',
+      height: 'auto',
+      gap: 'normal',
+      rowGap: 'normal',
+      columnGap: 'normal',
+      alignItems: 'normal',
+      justifyContent: 'normal',
+      placeItems: 'normal',
+      placeContent: 'normal',
+      columnCount: 'auto',
+      flexDirection: 'row',
+      flexWrap: 'nowrap',
+      ...overrides,
+    },
+    parent: null,
+  };
+}
+
+describe('flex-no-container-props: flex-direction/wrap on non-flex', () => {
+  it('warns when flex-direction is set on block element', () => {
+    const warnings = checkFlexContainerProps(
+      createRuleContext(makeElement({ flexDirection: 'column' })),
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].ruleId).toBe('flex-no-container-props');
+    expect(warnings[0].property).toBe('flex-direction');
+    expect(warnings[0].title).toContain('flex-direction');
+  });
+
+  it('warns when flex-wrap is set on block element', () => {
+    const warnings = checkFlexContainerProps(createRuleContext(makeElement({ flexWrap: 'wrap' })));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].property).toBe('flex-wrap');
+    expect(warnings[0].title).toContain('flex-wrap');
+  });
+
+  it('warns for both flex-direction and flex-wrap', () => {
+    const warnings = checkFlexContainerProps(
+      createRuleContext(makeElement({ flexDirection: 'column', flexWrap: 'wrap' })),
+    );
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0].property).toBe('flex-direction');
+    expect(warnings[1].property).toBe('flex-wrap');
+  });
+
+  it('skips flex containers', () => {
+    const warnings = checkFlexContainerProps(
+      createRuleContext(makeElement({ display: 'flex', flexDirection: 'column' })),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('skips inline-flex containers', () => {
+    const warnings = checkFlexContainerProps(
+      createRuleContext(makeElement({ display: 'inline-flex', flexWrap: 'wrap' })),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('skips grid containers', () => {
+    const warnings = checkFlexContainerProps(
+      createRuleContext(makeElement({ display: 'grid', flexDirection: 'column' })),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('skips inline-grid containers', () => {
+    const warnings = checkFlexContainerProps(
+      createRuleContext(makeElement({ display: 'inline-grid', flexWrap: 'wrap' })),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('skips when values are defaults (row + nowrap)', () => {
+    const warnings = checkFlexContainerProps(createRuleContext(makeElement({})));
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('skips display: contents elements', () => {
+    const warnings = checkFlexContainerProps(
+      createRuleContext(makeElement({ display: 'contents', flexDirection: 'column' })),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('warns on inline elements with flex-direction', () => {
+    const warnings = checkFlexContainerProps(
+      createRuleContext(makeElement({ display: 'inline', flexDirection: 'column-reverse' })),
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].property).toBe('flex-direction');
+  });
+
+  it('warns on table elements with flex-wrap', () => {
+    const warnings = checkFlexContainerProps(
+      createRuleContext(makeElement({ display: 'table', flexWrap: 'wrap-reverse' })),
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].property).toBe('flex-wrap');
+  });
+});

--- a/src/rules/__tests__/validation.test.ts
+++ b/src/rules/__tests__/validation.test.ts
@@ -6,6 +6,12 @@ import '../inline-dimensions.ts';
 import '../gap.ts';
 import '../alignment.ts';
 import '../place.ts';
+import '../static-position-offset.ts';
+import '../self-alignment.ts';
+import '../order.ts';
+import '../block-vertical-align.ts';
+import '../static-z-index.ts';
+import '../flex-container-props.ts';
 
 const VALID_STYLES = {
   display: 'block',
@@ -19,6 +25,29 @@ const VALID_STYLES = {
   placeItems: 'normal',
   placeContent: 'normal',
   columnCount: 'auto',
+  position: 'static',
+  top: 'auto',
+  right: 'auto',
+  bottom: 'auto',
+  left: 'auto',
+  alignSelf: 'auto',
+  order: '0',
+  marginTop: '0px',
+  marginBottom: '0px',
+  verticalAlign: 'baseline',
+  zIndex: 'auto',
+  opacity: '1',
+  transform: 'none',
+  filter: 'none',
+  backdropFilter: 'none',
+  perspective: 'none',
+  clipPath: 'none',
+  isolation: 'auto',
+  mixBlendMode: 'normal',
+  contain: 'none',
+  willChange: 'auto',
+  flexDirection: 'row',
+  flexWrap: 'nowrap',
 };
 
 describe('isElementData — parent field validation', () => {

--- a/src/rules/context.ts
+++ b/src/rules/context.ts
@@ -142,3 +142,11 @@ export function isStackingContext(styles: Record<string, string>): boolean {
 
   return false;
 }
+
+export function isDefaultFlexDirectionValue(value: string): boolean {
+  return value === 'row';
+}
+
+export function isDefaultFlexWrapValue(value: string): boolean {
+  return value === 'nowrap';
+}

--- a/src/rules/engine.ts
+++ b/src/rules/engine.ts
@@ -9,6 +9,7 @@ import './self-alignment.ts';
 import './order.ts';
 import './block-vertical-align.ts';
 import './static-z-index.ts';
+import './flex-container-props.ts';
 
 import type { ElementData, Warning } from './types.ts';
 import { createRuleContext } from './context.ts';

--- a/src/rules/flex-container-props.ts
+++ b/src/rules/flex-container-props.ts
@@ -1,0 +1,54 @@
+import type { RuleDescriptor, Warning } from './types.ts';
+import {
+  isDefaultFlexDirectionValue,
+  isDefaultFlexWrapValue,
+  isFlexOrGridContainer,
+} from './context.ts';
+import { registerRule } from './registry.ts';
+
+const rule: RuleDescriptor = {
+  id: 'flex-no-container-props',
+  label: 'flex-direction/wrap on non-flex',
+  requiredProperties: ['display', 'flexDirection', 'flexWrap'],
+  check(ctx) {
+    const { display, flexDirection, flexWrap } = ctx.styles;
+    // Grid containers also ignore flex-direction/flex-wrap, but we skip them
+    // to avoid noise when both grid and flex properties coexist for responsive
+    // breakpoint switching. See: https://github.com/purupurupu/css-noop-checker/issues/40
+    if (isFlexOrGridContainer(display)) return [];
+    // display:contents removes the element's box; flex properties are inapplicable.
+    if (display === 'contents') return [];
+
+    const warnings: Warning[] = [];
+
+    if (!isDefaultFlexDirectionValue(flexDirection)) {
+      warnings.push({
+        ruleId: 'flex-no-container-props',
+        property: 'flex-direction',
+        severity: 'warning',
+        title: 'flex-direction has no effect',
+        details: `flex-direction is "${flexDirection}" but display is "${display}". flex-direction works on flex containers only.`,
+        suggestion:
+          'Set display: flex or display: inline-flex on this element, or remove flex-direction.',
+      });
+    }
+
+    if (!isDefaultFlexWrapValue(flexWrap)) {
+      warnings.push({
+        ruleId: 'flex-no-container-props',
+        property: 'flex-wrap',
+        severity: 'warning',
+        title: 'flex-wrap has no effect',
+        details: `flex-wrap is "${flexWrap}" but display is "${display}". flex-wrap works on flex containers only.`,
+        suggestion:
+          'Set display: flex or display: inline-flex on this element, or remove flex-wrap.',
+      });
+    }
+
+    return warnings;
+  },
+};
+
+registerRule(rule);
+
+export const checkFlexContainerProps = rule.check;

--- a/src/sidebar/hooks/__tests__/usePageScan.hook.test.tsx
+++ b/src/sidebar/hooks/__tests__/usePageScan.hook.test.tsx
@@ -19,6 +19,8 @@ function makeBaseStyles(overrides: Record<string, string> = {}): Record<string, 
     width: 'auto',
     height: 'auto',
     verticalAlign: 'baseline',
+    flexDirection: 'row',
+    flexWrap: 'nowrap',
     ...overrides,
   };
 }

--- a/src/sidebar/hooks/__tests__/usePageScan.test.ts
+++ b/src/sidebar/hooks/__tests__/usePageScan.test.ts
@@ -30,6 +30,8 @@ function makeScanElement(
       alignSelf: 'auto',
       order: '0',
       verticalAlign: 'baseline',
+      flexDirection: 'row',
+      flexWrap: 'nowrap',
       ...styles,
     },
   };

--- a/src/sidebar/hooks/__tests__/useSelectedElement.test.ts
+++ b/src/sidebar/hooks/__tests__/useSelectedElement.test.ts
@@ -40,6 +40,8 @@ const validData = {
     mixBlendMode: 'normal',
     contain: 'none',
     willChange: 'auto',
+    flexDirection: 'row',
+    flexWrap: 'nowrap',
   },
   parent: null,
 };
@@ -166,6 +168,8 @@ describe('isElementData', () => {
       'mixBlendMode',
       'contain',
       'willChange',
+      'flexDirection',
+      'flexWrap',
     ];
     for (const key of requiredKeys) {
       const styles = { ...validData.computedStyles };


### PR DESCRIPTION
## Summary

- Add `flex-no-container-props` rule detecting `flex-direction`/`flex-wrap` on non-flex elements (closes #15)
- Add `isDefaultFlexDirectionValue`/`isDefaultFlexWrapValue` helpers to `context.ts`
- Skip grid/inline-grid containers to avoid false positives in responsive designs (#40)
- Skip `display: contents` for consistency with all other container rules
- Update `validation.test.ts` to register all rules and include full property set
- Add engine integration test verifying the rule fires through `analyzeElement()`
- Fix pre-existing CLAUDE.md table: `container-no-place` now shows `place-content/place-items`

| Design Decision | Choice | Rationale |
|---|---|---|
| Rule ID | `flex-no-container-props` | Opens `flex-no-*` namespace for future flex-specific rules |
| Grid guard | `isFlexOrGridContainer` | Avoids noise in responsive designs; revisit in #40 |
| `display: contents` | Skip (no warning) | Consistent with all other container rules |
| Shared abstraction | None | Current helper-based composition in `context.ts` is sufficient |

## Test plan

- [ ] `pnpm test` — all 144 tests pass (11 new rule tests + 1 engine integration)
- [ ] `pnpm build` — type-check and bundle succeed
- [ ] `pnpm lint` — 0 warnings
- [ ] Load extension in Chrome DevTools, open `examples/test.html`:
  - [ ] Select `div` with `flex-direction: column` (block) → warning appears
  - [ ] Select `div` with `flex-wrap: wrap` (block) → warning appears
  - [ ] Select `div` with `flex-flow: column wrap` (block) → two warnings appear
  - [ ] Select `div` with `display: flex; flex-direction: column` → no warning
  - [ ] Select `div` with `display: grid; flex-direction: column` → no warning
  - [ ] Select plain `div` (no overrides) → no warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)