### PR TITLE
fix: resolve React Hooks violations in sidebar

### DIFF
--- a/src/sidebar/components/ScanResultsPanel.tsx
+++ b/src/sidebar/components/ScanResultsPanel.tsx
@@ -22,6 +22,12 @@ export function ScanResultsPanel({
   onInspect,
   onClear,
 }: ScanResultsPanelProps) {
+  const { totalViolations, uniqueElements } = useMemo(() => {
+    const total = groups.reduce((sum, g) => sum + g.violations.length, 0);
+    const unique = new Set(groups.flatMap((g) => g.violations.map((v) => v.index))).size;
+    return { totalViolations: total, uniqueElements: unique };
+  }, [groups]);
+
   if (status === 'scanning') {
     const text =
       progress.total > 0
@@ -60,12 +66,6 @@ export function ScanResultsPanel({
   }
 
   if (status !== 'done') return null;
-
-  const { totalViolations, uniqueElements } = useMemo(() => {
-    const total = groups.reduce((sum, g) => sum + g.violations.length, 0);
-    const unique = new Set(groups.flatMap((g) => g.violations.map((v) => v.index))).size;
-    return { totalViolations: total, uniqueElements: unique };
-  }, [groups]);
 
   return (
     <div className="scan-results">

--- a/src/sidebar/components/ScanRuleGroup.tsx
+++ b/src/sidebar/components/ScanRuleGroup.tsx
@@ -22,7 +22,7 @@ export function ScanRuleGroup({ group, defaultOpen, onInspect }: ScanRuleGroupPr
     <div className="scan-rule-group">
       <button
         className="scan-rule-group__header"
-        onClick={() => setOpen(!open)}
+        onClick={() => setOpen((prev) => !prev)}
         type="button"
         aria-expanded={open}
         aria-controls={bodyId}


### PR DESCRIPTION
## Summary

- **Move `useMemo` before early returns** in `ScanResultsPanel.tsx` — the hook was called after 4 early returns, violating React Rules of Hooks. The hook call count varied depending on `status`, which could corrupt React's internal state.
- **Switch to functional `setState`** in `ScanRuleGroup.tsx` — `setOpen(!open)` referenced a stale closure value; replaced with `setOpen((prev) => !prev)` to always use the latest state.

| Decision | Rationale |
|----------|-----------|
| `useMemo` runs on all render paths | `groups` defaults to `[]`, so reduce/flatMap on empty array is safe (returns 0 / empty set) |
| No guard needed for non-`done` status | Computed values are simply unused in early-return branches — zero overhead |

## Test plan

- [x] `pnpm build` — type-check + bundle passes
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm test` — 214 tests pass (19 test files)
- [x] `pnpm fmt` — formatting applied
- [ ] Manual: load extension in Chrome, verify sidebar renders correctly in all states (scanning, error, empty, results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)