### PR TITLE
feat: add 3-round cross-review feedback loop to team-dev skill

### DIFF
--- a/.claude/skills/team-dev/SKILL.md
+++ b/.claude/skills/team-dev/SKILL.md
@@ -87,11 +87,11 @@ For each of the 3 review→fix rounds:
 
 ### Final Verdicts
 
-| Reviewer          | Verdict                            | Rationale |
-| ----------------- | ---------------------------------- | --------- |
-| Architect         | PASS / CONDITIONAL PASS / FAIL     |           |
-| Frontend Lead     | PASS / CONDITIONAL PASS / FAIL     |           |
-| Devil's Advocate  | PASS / CONDITIONAL PASS / FAIL     |           |
+| Reviewer         | Verdict                        | Rationale |
+| ---------------- | ------------------------------ | --------- |
+| Architect        | PASS / CONDITIONAL PASS / FAIL |           |
+| Frontend Lead    | PASS / CONDITIONAL PASS / FAIL |           |
+| Devil's Advocate | PASS / CONDITIONAL PASS / FAIL |           |
 
 ### Remaining Items
 


### PR DESCRIPTION
## Summary

- Add iterative cross-review feedback loop (×3) to the team-dev orchestrator skill
- After the initial review round, each agent (architect, frontend-lead, devil's-advocate) critiques the other two members' reviews and revises their own — repeated 3 times
- Add convergence tracking between rounds and a "Review Evolution" section to the final output
- Ensures findings are stress-tested through inter-member critique before synthesis

## Test plan

- [ ] Run `/team-dev` with a feature spec and verify all 4 review rounds execute (1 initial + 3 feedback)
- [ ] Confirm each feedback round includes both "Feedback for Other Members" and "Revised Review" sections
- [ ] Verify the final synthesis includes the new "Review Evolution" section
- [ ] Check that convergence notes appear between rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)