### PR TITLE
test: add React component rendering tests for sidebar UI

### DIFF
--- a/src/sidebar/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/sidebar/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { ErrorBoundary } from '../ErrorBoundary.tsx';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  cleanup();
+});
+
+/** Helper component that throws on demand. */
+let shouldThrow = false;
+
+function ThrowingChild() {
+  if (shouldThrow) {
+    throw new Error('Test error message');
+  }
+  return <div>Child content</div>;
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    shouldThrow = false;
+    // Suppress React error boundary console.error noise in test output
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('renders children when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <div>Hello</div>
+      </ErrorBoundary>,
+    );
+    screen.getByText('Hello');
+  });
+
+  it('shows "Something went wrong" when a child throws', () => {
+    shouldThrow = true;
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    );
+    screen.getByText('Something went wrong');
+  });
+
+  it('shows the error message when a child throws', () => {
+    shouldThrow = true;
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    );
+    screen.getByText('Test error message');
+  });
+
+  it('shows a Retry button when in error state', () => {
+    shouldThrow = true;
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    );
+    screen.getByText('Retry');
+  });
+
+  it('calls console.error at least once when a child throws', () => {
+    shouldThrow = true;
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    );
+    // React calls console.error for the error boundary + componentDidCatch logs once
+    // We verify console.error was actually called (not zero times)
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('recovers and re-renders children when Retry is clicked', () => {
+    shouldThrow = true;
+    render(
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>,
+    );
+
+    screen.getByText('Something went wrong');
+
+    // Fix the error condition and click Retry
+    shouldThrow = false;
+    fireEvent.click(screen.getByText('Retry'));
+
+    // Verify error UI is gone and children are rendered
+    screen.getByText('Child content');
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+    expect(screen.queryByText('Retry')).toBeNull();
+  });
+});

--- a/src/sidebar/components/__tests__/PanelHeader.test.tsx
+++ b/src/sidebar/components/__tests__/PanelHeader.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import type { ElementData } from '../../../rules/types.ts';
+import type { AnalysisStatus } from '../../hooks/useSelectedElement.ts';
+import type { ScanStatus } from '../../types.ts';
+import { PanelHeader } from '../PanelHeader.tsx';
+
+afterEach(cleanup);
+
+const makeElementData = (overrides: Partial<ElementData> = {}): ElementData => ({
+  tagName: 'div',
+  id: '',
+  classList: [],
+  computedStyles: {},
+  parent: null,
+  ...overrides,
+});
+
+describe('PanelHeader', () => {
+  const defaultProps = {
+    elementData: null as ElementData | null,
+    status: 'no-selection' as AnalysisStatus,
+    scanStatus: 'idle' as ScanStatus,
+    onScan: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows "No element selected" when elementData is null', () => {
+    render(<PanelHeader {...defaultProps} />);
+    screen.getByText('No element selected');
+  });
+
+  it('displays tagName only when no id or classes', () => {
+    render(<PanelHeader {...defaultProps} elementData={makeElementData({ tagName: 'span' })} />);
+    screen.getByText('span');
+  });
+
+  it('displays tagName#id when id is present', () => {
+    render(
+      <PanelHeader
+        {...defaultProps}
+        elementData={makeElementData({ tagName: 'div', id: 'app' })}
+      />,
+    );
+    screen.getByText('div#app');
+  });
+
+  it('displays tagName.class1.class2 when classes are present', () => {
+    render(
+      <PanelHeader
+        {...defaultProps}
+        elementData={makeElementData({ tagName: 'div', classList: ['foo', 'bar'] })}
+      />,
+    );
+    screen.getByText('div.foo.bar');
+  });
+
+  it('displays full selector tagName#id.class', () => {
+    render(
+      <PanelHeader
+        {...defaultProps}
+        elementData={makeElementData({ tagName: 'section', id: 'main', classList: ['active'] })}
+      />,
+    );
+    screen.getByText('section#main.active');
+  });
+
+  it('shows correct status label for each AnalysisStatus', () => {
+    const statuses: [AnalysisStatus, string][] = [
+      ['no-selection', 'No selection'],
+      ['analyzing', 'Analyzing...'],
+      ['ready', 'Ready'],
+      ['error', 'Error'],
+    ];
+
+    for (const [status, label] of statuses) {
+      const { unmount } = render(<PanelHeader {...defaultProps} status={status} />);
+      screen.getByText(label);
+      unmount();
+    }
+  });
+
+  it('applies dynamic CSS class based on status', () => {
+    const { container } = render(<PanelHeader {...defaultProps} status="analyzing" />);
+    const statusSpan = container.querySelector('.panel-header__status--analyzing');
+    expect(statusSpan).not.toBeNull();
+  });
+
+  it('shows "Scan Page" button when not scanning', () => {
+    render(<PanelHeader {...defaultProps} scanStatus="idle" />);
+    const button = screen.getByRole('button');
+    expect(button.textContent).toBe('Scan Page');
+    expect(button.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('shows "Scanning\u2026" and disables button when scanStatus is scanning', () => {
+    render(<PanelHeader {...defaultProps} scanStatus="scanning" />);
+    const button = screen.getByRole('button');
+    expect(button.textContent).toBe('Scanning\u2026');
+    expect(button.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('calls onScan when Scan Page button is clicked', () => {
+    const onScan = vi.fn();
+    render(<PanelHeader {...defaultProps} onScan={onScan} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onScan).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onScan when button is disabled (scanning)', () => {
+    const onScan = vi.fn();
+    render(<PanelHeader {...defaultProps} scanStatus="scanning" onScan={onScan} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onScan).not.toHaveBeenCalled();
+  });
+});

--- a/src/sidebar/components/__tests__/ScanResultsPanel.test.tsx
+++ b/src/sidebar/components/__tests__/ScanResultsPanel.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import type { ScanGroup, ScanProgress, ScanStatus } from '../../types.ts';
+import { ScanResultsPanel } from '../ScanResultsPanel.tsx';
+
+afterEach(cleanup);
+
+vi.mock('../../../rules/registry.ts', () => ({
+  getRuleLabel: (id: string) => `Label for ${id}`,
+}));
+
+const makeGroup = (ruleId: string, violationCount: number, startIndex = 0): ScanGroup => ({
+  ruleId,
+  violations: Array.from({ length: violationCount }, (_, i) => ({
+    index: startIndex + i,
+    selector: `div.item-${startIndex + i}`,
+    warnings: [
+      {
+        ruleId,
+        property: 'width',
+        severity: 'warning' as const,
+        title: 'No-op',
+        details: 'Details',
+        suggestion: 'Suggestion',
+      },
+    ],
+  })),
+});
+
+const defaultProps = {
+  groups: [] as ScanGroup[],
+  status: 'idle' as ScanStatus,
+  error: null as string | null,
+  inspectError: null as string | null,
+  progress: { scanned: 0, total: 0 } as ScanProgress,
+  onInspect: vi.fn(),
+  onClear: vi.fn(),
+};
+
+describe('ScanResultsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when status is idle', () => {
+    const { container } = render(<ScanResultsPanel {...defaultProps} status="idle" />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders nothing when status is idle even with groups', () => {
+    const groups = [makeGroup('inline-no-dimensions', 2)];
+    const { container } = render(
+      <ScanResultsPanel {...defaultProps} status="idle" groups={groups} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('shows scanning message with progress', () => {
+    render(
+      <ScanResultsPanel {...defaultProps} status="scanning" progress={{ scanned: 5, total: 10 }} />,
+    );
+    screen.getByText('Scanning\u2026 (5/10 elements)');
+  });
+
+  it('shows scanning message without progress when total is 0', () => {
+    render(
+      <ScanResultsPanel {...defaultProps} status="scanning" progress={{ scanned: 0, total: 0 }} />,
+    );
+    screen.getByText('Scanning\u2026');
+  });
+
+  it('shows Cancel button during scanning', () => {
+    render(<ScanResultsPanel {...defaultProps} status="scanning" />);
+    screen.getByText('Cancel');
+  });
+
+  it('calls onClear when Cancel is clicked during scanning', () => {
+    const onClear = vi.fn();
+    render(<ScanResultsPanel {...defaultProps} status="scanning" onClear={onClear} />);
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows error message when status is error', () => {
+    render(<ScanResultsPanel {...defaultProps} status="error" error="Something broke" />);
+    screen.getByText('Something broke');
+  });
+
+  it('shows fallback error message when error is null', () => {
+    render(<ScanResultsPanel {...defaultProps} status="error" error={null} />);
+    screen.getByText('Scan failed');
+  });
+
+  it('shows Back button when status is error', () => {
+    render(<ScanResultsPanel {...defaultProps} status="error" />);
+    screen.getByText('Back');
+  });
+
+  it('calls onClear when Back is clicked in error state', () => {
+    const onClear = vi.fn();
+    render(<ScanResultsPanel {...defaultProps} status="error" onClear={onClear} />);
+    fireEvent.click(screen.getByText('Back'));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows "No violations found." when done with empty groups', () => {
+    render(<ScanResultsPanel {...defaultProps} status="done" groups={[]} />);
+    screen.getByText('No violations found.');
+  });
+
+  it('shows Back button when done with no violations', () => {
+    render(<ScanResultsPanel {...defaultProps} status="done" groups={[]} />);
+    screen.getByText('Back');
+  });
+
+  it('calls onClear when Back is clicked in done-empty state', () => {
+    const onClear = vi.fn();
+    render(<ScanResultsPanel {...defaultProps} status="done" groups={[]} onClear={onClear} />);
+    fireEvent.click(screen.getByText('Back'));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders ScanSummaryBar with correct counts when done with results', () => {
+    const groups = [makeGroup('inline-no-dimensions', 2), makeGroup('container-no-gap', 3, 2)];
+    const { container } = render(
+      <ScanResultsPanel {...defaultProps} status="done" groups={groups} />,
+    );
+
+    // ScanSummaryBar shows total violations via <strong> element
+    const countEl = container.querySelector('.scan-summary__count');
+    expect(countEl?.textContent).toBe('5');
+    // Verify unique element count (5 unique indices: 0,1,2,3,4)
+    const summarySpan = container.querySelector('.scan-summary > span');
+    expect(summarySpan).not.toBeNull();
+    expect(summarySpan!.textContent).toContain('5 elements');
+    // Verify rule count
+    expect(summarySpan!.textContent).toContain('2 rules');
+    // ScanRuleGroup renders rule badges
+    screen.getByText('inline-no-dimensions');
+    screen.getByText('container-no-gap');
+  });
+
+  it('deduplicates overlapping element indices in uniqueElements count', () => {
+    // Both groups share element indices 0 and 1
+    const groups = [
+      makeGroup('inline-no-dimensions', 3, 0), // indices: 0, 1, 2
+      makeGroup('container-no-gap', 3, 1), // indices: 1, 2, 3
+    ];
+    const { container } = render(
+      <ScanResultsPanel {...defaultProps} status="done" groups={groups} />,
+    );
+
+    // Total violations = 6, but unique elements = 4 (indices: 0, 1, 2, 3)
+    const countEl = container.querySelector('.scan-summary__count');
+    expect(countEl?.textContent).toBe('6');
+    const summarySpan = container.querySelector('.scan-summary > span');
+    expect(summarySpan).not.toBeNull();
+    expect(summarySpan!.textContent).toContain('4 elements');
+  });
+
+  it('renders inspectError alert when present', () => {
+    const groups = [makeGroup('inline-no-dimensions', 1)];
+    const { container } = render(
+      <ScanResultsPanel
+        {...defaultProps}
+        status="done"
+        groups={groups}
+        inspectError="Could not inspect element"
+      />,
+    );
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    screen.getByText('Could not inspect element');
+  });
+
+  it('does not render inspectError when null', () => {
+    const groups = [makeGroup('inline-no-dimensions', 1)];
+    const { container } = render(
+      <ScanResultsPanel {...defaultProps} status="done" groups={groups} inspectError={null} />,
+    );
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('first group is defaultOpen, second is collapsed', () => {
+    const groups = [makeGroup('rule-a', 1), makeGroup('rule-b', 1, 1)];
+    const { container } = render(
+      <ScanResultsPanel {...defaultProps} status="done" groups={groups} />,
+    );
+
+    const headerButtons = container.querySelectorAll('.scan-rule-group__header');
+    expect(headerButtons[0].getAttribute('aria-expanded')).toBe('true');
+    expect(headerButtons[1].getAttribute('aria-expanded')).toBe('false');
+  });
+});

--- a/src/sidebar/components/__tests__/ScanRuleGroup.test.tsx
+++ b/src/sidebar/components/__tests__/ScanRuleGroup.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import type { ScanGroup } from '../../types.ts';
+import { ScanRuleGroup } from '../ScanRuleGroup.tsx';
+
+afterEach(cleanup);
+
+vi.mock('../../../rules/registry.ts', () => ({
+  getRuleLabel: (id: string) => `Label for ${id}`,
+}));
+
+const makeGroup = (overrides: Partial<ScanGroup> = {}): ScanGroup => ({
+  ruleId: 'inline-no-dimensions',
+  violations: [
+    {
+      index: 0,
+      selector: 'span.item',
+      warnings: [
+        {
+          ruleId: 'inline-no-dimensions',
+          property: 'width',
+          severity: 'warning',
+          title: 'Width no-op',
+          details: 'Details',
+          suggestion: 'Suggestion',
+        },
+      ],
+    },
+  ],
+  ...overrides,
+});
+
+describe('ScanRuleGroup', () => {
+  const defaultProps = {
+    group: makeGroup(),
+    defaultOpen: false,
+    onInspect: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the ruleId badge', () => {
+    render(<ScanRuleGroup {...defaultProps} />);
+    screen.getByText('inline-no-dimensions');
+  });
+
+  it('renders the label from getRuleLabel', () => {
+    render(<ScanRuleGroup {...defaultProps} />);
+    screen.getByText('Label for inline-no-dimensions');
+  });
+
+  it('renders the violation count', () => {
+    render(<ScanRuleGroup {...defaultProps} />);
+    screen.getByText('(1)');
+  });
+
+  it('starts collapsed when defaultOpen is false', () => {
+    const { container } = render(<ScanRuleGroup {...defaultProps} defaultOpen={false} />);
+    const button = container.querySelector('button[aria-expanded="false"]');
+    expect(button).not.toBeNull();
+    expect(screen.queryByText('span.item')).toBeNull();
+  });
+
+  it('starts expanded when defaultOpen is true', () => {
+    const { container } = render(<ScanRuleGroup {...defaultProps} defaultOpen={true} />);
+    const button = container.querySelector('button[aria-expanded="true"]');
+    expect(button).not.toBeNull();
+    screen.getByText('span.item');
+  });
+
+  it('toggles expand/collapse on header click', () => {
+    const { container } = render(<ScanRuleGroup {...defaultProps} defaultOpen={false} />);
+    const button = container.querySelector('.scan-rule-group__header')!;
+
+    // Expand
+    fireEvent.click(button);
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+    screen.getByText('span.item');
+
+    // Collapse
+    fireEvent.click(button);
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByText('span.item')).toBeNull();
+  });
+
+  it('shows "and X more" when violations exceed DISPLAY_LIMIT and renders exactly 50 rows', () => {
+    const violations = Array.from({ length: 55 }, (_, i) => ({
+      index: i,
+      selector: `div.item-${i}`,
+      warnings: [
+        {
+          ruleId: 'inline-no-dimensions',
+          property: 'width',
+          severity: 'warning' as const,
+          title: 'No-op',
+          details: 'Details',
+          suggestion: 'Suggestion',
+        },
+      ],
+    }));
+    const group = makeGroup({ violations });
+
+    const { container } = render(
+      <ScanRuleGroup group={group} defaultOpen={true} onInspect={vi.fn()} />,
+    );
+
+    // Should show count (55) in header
+    screen.getByText('(55)');
+    // Should show overflow message (hellip renders as ...)
+    screen.getByText(/and 5 more/);
+    // Should render exactly 50 violation rows (DISPLAY_LIMIT)
+    const rows = container.querySelectorAll('.scan-violation-row');
+    expect(rows.length).toBe(50);
+  });
+
+  it('does not show overflow message when violations equal DISPLAY_LIMIT', () => {
+    const violations = Array.from({ length: 50 }, (_, i) => ({
+      index: i,
+      selector: `div.item-${i}`,
+      warnings: [
+        {
+          ruleId: 'inline-no-dimensions',
+          property: 'width',
+          severity: 'warning' as const,
+          title: 'No-op',
+          details: 'Details',
+          suggestion: 'Suggestion',
+        },
+      ],
+    }));
+    const group = makeGroup({ violations });
+
+    const { container } = render(
+      <ScanRuleGroup group={group} defaultOpen={true} onInspect={vi.fn()} />,
+    );
+
+    // Should show count (50) in header
+    screen.getByText('(50)');
+    // Should NOT show overflow message at exactly 50
+    expect(screen.queryByText(/and \d+ more/)).toBeNull();
+    // Should render all 50 violation rows
+    const rows = container.querySelectorAll('.scan-violation-row');
+    expect(rows.length).toBe(50);
+  });
+
+  it('does not show overflow message when violations are within DISPLAY_LIMIT', () => {
+    render(<ScanRuleGroup {...defaultProps} defaultOpen={true} />);
+    expect(screen.queryByText(/and \d+ more/)).toBeNull();
+  });
+
+  it('calls onInspect with correct index when a violation row is clicked (index=0)', () => {
+    const onInspect = vi.fn();
+    const { container } = render(
+      <ScanRuleGroup {...defaultProps} defaultOpen={true} onInspect={onInspect} />,
+    );
+
+    // Click the violation row button
+    const violationButton = container.querySelector('.scan-violation-row');
+    fireEvent.click(violationButton!);
+    expect(onInspect).toHaveBeenCalledWith(0);
+  });
+
+  it('calls onInspect with non-zero index to verify index is passed through', () => {
+    const onInspect = vi.fn();
+    const group = makeGroup({
+      violations: [
+        {
+          index: 42,
+          selector: 'div.deep-nested',
+          warnings: [
+            {
+              ruleId: 'inline-no-dimensions',
+              property: 'width',
+              severity: 'warning',
+              title: 'Width no-op',
+              details: 'Details',
+              suggestion: 'Suggestion',
+            },
+          ],
+        },
+      ],
+    });
+    const { container } = render(
+      <ScanRuleGroup group={group} defaultOpen={true} onInspect={onInspect} />,
+    );
+
+    const violationButton = container.querySelector('.scan-violation-row');
+    fireEvent.click(violationButton!);
+    expect(onInspect).toHaveBeenCalledWith(42);
+  });
+
+  it('aria-controls on header matches body region id', () => {
+    const { container } = render(<ScanRuleGroup {...defaultProps} defaultOpen={true} />);
+    const header = container.querySelector('.scan-rule-group__header')!;
+    const controlsId = header.getAttribute('aria-controls');
+    const body = container.querySelector(`#${controlsId}`);
+    expect(body).not.toBeNull();
+    expect(body!.getAttribute('role')).toBe('region');
+  });
+});

--- a/src/sidebar/components/__tests__/ScanSummaryBar.test.tsx
+++ b/src/sidebar/components/__tests__/ScanSummaryBar.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { ScanSummaryBar } from '../ScanSummaryBar.tsx';
+
+afterEach(cleanup);
+
+describe('ScanSummaryBar', () => {
+  const defaultProps = {
+    totalViolations: 5,
+    totalElements: 3,
+    ruleCount: 2,
+    onClear: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('displays violation count in the strong element', () => {
+    const { container } = render(<ScanSummaryBar {...defaultProps} />);
+    const countEl = container.querySelector('.scan-summary__count');
+    expect(countEl?.textContent).toBe('5');
+  });
+
+  it('displays summary text with elements and rules', () => {
+    const { container } = render(<ScanSummaryBar {...defaultProps} />);
+    const summarySpan = container.querySelector('.scan-summary > span');
+    expect(summarySpan?.textContent).toContain('3 elements');
+    expect(summarySpan?.textContent).toContain('2 rules');
+  });
+
+  it('renders clear button with correct aria-label', () => {
+    const { container } = render(<ScanSummaryBar {...defaultProps} />);
+    const button = container.querySelector('button[aria-label="Clear results"]');
+    expect(button).not.toBeNull();
+  });
+
+  it('calls onClear when clear button is clicked', () => {
+    const onClear = vi.fn();
+    const { container } = render(<ScanSummaryBar {...defaultProps} onClear={onClear} />);
+    const button = container.querySelector('button[aria-label="Clear results"]');
+    fireEvent.click(button!);
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/sidebar/components/__tests__/ScanViolationRow.test.tsx
+++ b/src/sidebar/components/__tests__/ScanViolationRow.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import type { ScanViolation } from '../../types.ts';
+import { ScanViolationRow } from '../ScanViolationRow.tsx';
+
+afterEach(cleanup);
+
+const makeViolation = (overrides: Partial<ScanViolation> = {}): ScanViolation => ({
+  index: 0,
+  selector: 'div.container',
+  warnings: [
+    {
+      ruleId: 'inline-no-dimensions',
+      property: 'width',
+      severity: 'warning',
+      title: 'Width no-op',
+      details: 'Details',
+      suggestion: 'Suggestion',
+    },
+  ],
+  ...overrides,
+});
+
+describe('ScanViolationRow', () => {
+  it('renders the selector in a code element', () => {
+    render(<ScanViolationRow violation={makeViolation()} onInspect={vi.fn()} />);
+    const code = screen.getByText('div.container');
+    expect(code.tagName).toBe('CODE');
+  });
+
+  it('renders joined property names from warnings', () => {
+    const violation = makeViolation({
+      warnings: [
+        {
+          ruleId: 'r1',
+          property: 'width',
+          severity: 'warning',
+          title: 't',
+          details: 'd',
+          suggestion: 's',
+        },
+        {
+          ruleId: 'r2',
+          property: 'height',
+          severity: 'warning',
+          title: 't',
+          details: 'd',
+          suggestion: 's',
+        },
+      ],
+    });
+    render(<ScanViolationRow violation={violation} onInspect={vi.fn()} />);
+    screen.getByText('width, height');
+  });
+
+  it('calls onInspect when clicked', () => {
+    const onInspect = vi.fn();
+    render(<ScanViolationRow violation={makeViolation()} onInspect={onInspect} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onInspect).toHaveBeenCalledTimes(1);
+  });
+
+  it('has correct aria-label with selector and single property', () => {
+    const { container } = render(
+      <ScanViolationRow violation={makeViolation()} onInspect={vi.fn()} />,
+    );
+    const button = container.querySelector('button[aria-label="Inspect div.container: width"]');
+    expect(button).not.toBeNull();
+  });
+
+  it('has correct aria-label with selector and multiple properties', () => {
+    const violation = makeViolation({
+      warnings: [
+        {
+          ruleId: 'r1',
+          property: 'width',
+          severity: 'warning',
+          title: 't',
+          details: 'd',
+          suggestion: 's',
+        },
+        {
+          ruleId: 'r2',
+          property: 'height',
+          severity: 'warning',
+          title: 't',
+          details: 'd',
+          suggestion: 's',
+        },
+      ],
+    });
+    const { container } = render(<ScanViolationRow violation={violation} onInspect={vi.fn()} />);
+    const button = container.querySelector(
+      'button[aria-label="Inspect div.container: width, height"]',
+    );
+    expect(button).not.toBeNull();
+  });
+});

--- a/src/sidebar/components/__tests__/WarningCard.test.tsx
+++ b/src/sidebar/components/__tests__/WarningCard.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import type { Warning } from '../../../rules/types.ts';
+import { WarningCard } from '../WarningCard.tsx';
+
+afterEach(cleanup);
+
+const makeWarning = (overrides: Partial<Warning> = {}): Warning => ({
+  ruleId: 'inline-no-dimensions',
+  property: 'width',
+  severity: 'warning',
+  title: 'Width has no effect',
+  details: 'Inline elements ignore width.',
+  suggestion: 'Use display: inline-block.',
+  ...overrides,
+});
+
+describe('WarningCard', () => {
+  it('renders the title', () => {
+    render(<WarningCard warning={makeWarning({ title: 'Test title' })} />);
+    screen.getByText('Test title');
+  });
+
+  it('renders the details', () => {
+    render(<WarningCard warning={makeWarning({ details: 'Some details here' })} />);
+    screen.getByText('Some details here');
+  });
+
+  it('renders the suggestion', () => {
+    render(<WarningCard warning={makeWarning({ suggestion: 'Try this instead' })} />);
+    screen.getByText('Try this instead');
+  });
+
+  it('renders the ruleId', () => {
+    render(<WarningCard warning={makeWarning({ ruleId: 'container-no-gap' })} />);
+    screen.getByText('container-no-gap');
+  });
+
+  it('renders warning icon with aria-label', () => {
+    const { container } = render(<WarningCard warning={makeWarning()} />);
+    const icon = container.querySelector('[aria-label="warning"]');
+    expect(icon).not.toBeNull();
+  });
+});

--- a/src/sidebar/components/__tests__/WarningList.test.tsx
+++ b/src/sidebar/components/__tests__/WarningList.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import type { Warning } from '../../../rules/types.ts';
+import { WarningList } from '../WarningList.tsx';
+
+afterEach(cleanup);
+
+const makeWarning = (overrides: Partial<Warning> = {}): Warning => ({
+  ruleId: 'inline-no-dimensions',
+  property: 'width',
+  severity: 'warning',
+  title: 'Width has no effect on inline elements',
+  details: 'Inline elements ignore width.',
+  suggestion: 'Use display: inline-block or block.',
+  ...overrides,
+});
+
+describe('WarningList', () => {
+  it('returns null when status is no-selection', () => {
+    const { container } = render(<WarningList warnings={[]} status="no-selection" />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('returns null when status is error', () => {
+    const { container } = render(<WarningList warnings={[]} status="error" />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('shows "Analyzing..." when status is analyzing', () => {
+    render(<WarningList warnings={[]} status="analyzing" />);
+    screen.getByText('Analyzing...');
+  });
+
+  it('shows "No issues detected" when status is ready with empty warnings', () => {
+    render(<WarningList warnings={[]} status="ready" />);
+    screen.getByText('No issues detected (MVP rules).');
+  });
+
+  it('renders WarningCard for each warning when ready with warnings', () => {
+    const warnings: Warning[] = [
+      makeWarning({ ruleId: 'inline-no-dimensions', property: 'width', title: 'Width no-op' }),
+      makeWarning({
+        ruleId: 'inline-no-vertical-margin',
+        property: 'margin-top',
+        title: 'Margin no-op',
+      }),
+    ];
+    render(<WarningList warnings={warnings} status="ready" />);
+    screen.getByText('Width no-op');
+    screen.getByText('Margin no-op');
+  });
+
+  it('does not render "No issues detected" when there are warnings', () => {
+    render(<WarningList warnings={[makeWarning()]} status="ready" />);
+    expect(screen.queryByText('No issues detected (MVP rules).')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Add rendering tests for all 8 sidebar UI components using `@testing-library/react` + `happy-dom` (67 new tests across 8 files)
- Cover conditional rendering branches, accessibility attributes (aria-expanded, aria-controls, aria-label), callback propagation, DISPLAY_LIMIT boundary behavior, and uniqueElements deduplication
- Uses per-file `// @vitest-environment happy-dom` directive to keep pure-logic tests in Node environment

## Components Covered

| Component | Tests | Key Coverage |
|---|---|---|
| PanelHeader | 11 | Selector display, status labels, dynamic CSS class, Scan button states |
| WarningList | 6 | 4-state conditional rendering (null, loading, empty, list) |
| WarningCard | 5 | All fields + aria-label |
| ScanSummaryBar | 4 | Metrics display, Clear button |
| ScanViolationRow | 5 | Selector, property join, aria-label (single/multi) |
| ScanRuleGroup | 12 | Expand/collapse, DISPLAY_LIMIT boundary (50/55), index passthrough, aria-controls |
| ScanResultsPanel | 18 | 5 status branches, dedup verification, onClear all paths, inspectError |
| ErrorBoundary | 6 | Error catch, Retry recovery, console.error verification |

## Test plan

- [x] `pnpm test` — 28 files, 290 tests all passing
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm build` — type-check + bundle succeeds
- [x] No source component changes — test files only

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)