### PR TITLE
feat: collect parent styles in page scan

### DIFF
--- a/e2e/integration/page-scan-rules.test.ts
+++ b/e2e/integration/page-scan-rules.test.ts
@@ -1,0 +1,169 @@
+import { test, expect } from '@playwright/test';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { extractElementData } from '../helpers/extract-element-data.ts';
+import { analyzeElement } from '../../src/rules/engine.ts';
+import { groupByRule } from '../../src/sidebar/utils/group-by-rule.ts';
+import type { ScanElementData } from '../../src/sidebar/types.ts';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const TEST_HTML = `file://${path.resolve(__dirname, '../../examples/test.html')}`;
+
+test.describe('page scan with parent context', () => {
+  test('groupByRule with parent context matches per-element analysis', async ({ page }) => {
+    await page.goto(TEST_HTML);
+
+    const cases = page.locator('.case[data-rule]');
+    const caseCount = await cases.count();
+    expect(caseCount).toBeGreaterThan(0);
+
+    // Build ScanElementData[] from all [data-target] elements (with parent styles)
+    const scanElements: ScanElementData[] = [];
+    for (let i = 0; i < caseCount; i++) {
+      const caseEl = cases.nth(i);
+      const target = caseEl.locator('[data-target]');
+      const targetCount = await target.count();
+      if (targetCount !== 1) continue;
+
+      const data = await extractElementData(target);
+      scanElements.push({
+        index: i,
+        selector: `case-${i}`,
+        tagName: data.tagName,
+        id: data.id,
+        classList: data.classList,
+        computedStyles: data.computedStyles,
+        parent: data.parent,
+      });
+    }
+
+    // Run groupByRule (which internally calls analyzeElement with parent context)
+    const groups = groupByRule(scanElements);
+
+    // Collect per-element warnings independently for comparison (unique rule IDs per element)
+    const perElementRules = new Map<number, Set<string>>();
+    for (const el of scanElements) {
+      const warnings = analyzeElement({
+        tagName: el.tagName,
+        id: el.id,
+        classList: el.classList,
+        computedStyles: el.computedStyles,
+        parent: el.parent,
+      });
+      if (warnings.length > 0) {
+        perElementRules.set(el.index, new Set(warnings.map((w) => w.ruleId)));
+      }
+    }
+
+    // Verify groupByRule results match per-element analysis
+    const groupedRules = new Map<number, Set<string>>();
+    for (const group of groups) {
+      for (const violation of group.violations) {
+        const existing = groupedRules.get(violation.index) ?? new Set();
+        existing.add(group.ruleId);
+        groupedRules.set(violation.index, existing);
+      }
+    }
+
+    // Both maps should contain the same elements with the same rule IDs
+    expect(groupedRules.size).toBe(perElementRules.size);
+    for (const [index, ruleIds] of perElementRules) {
+      const grouped = groupedRules.get(index);
+      expect(grouped, `element at index ${index} missing from groupByRule results`).toBeDefined();
+      expect([...ruleIds].sort()).toEqual([...grouped!].sort());
+    }
+  });
+
+  test('expect-warn cases produce warnings via groupByRule', async ({ page }) => {
+    await page.goto(TEST_HTML);
+
+    const warnCases = page.locator('.case.expect-warn[data-rule]');
+    const warnCount = await warnCases.count();
+    expect(warnCount).toBeGreaterThan(0);
+
+    // Build ScanElementData[] from expect-warn cases
+    const scanElements: ScanElementData[] = [];
+    const caseRules: { index: number; rule: string; label: string }[] = [];
+
+    for (let i = 0; i < warnCount; i++) {
+      const caseEl = warnCases.nth(i);
+      const rule = await caseEl.getAttribute('data-rule');
+      if (!rule || rule === 'none') continue;
+
+      const target = caseEl.locator('[data-target]');
+      const label = (await caseEl.locator('.label').textContent()) ?? `(index ${i})`;
+      const data = await extractElementData(target);
+
+      scanElements.push({
+        index: i,
+        selector: `warn-case-${i}`,
+        tagName: data.tagName,
+        id: data.id,
+        classList: data.classList,
+        computedStyles: data.computedStyles,
+        parent: data.parent,
+      });
+      caseRules.push({ index: i, rule, label });
+    }
+
+    const groups = groupByRule(scanElements);
+
+    // Every expect-warn case should appear in the group for its data-rule
+    for (const { index, rule, label } of caseRules) {
+      const group = groups.find((g) => g.ruleId === rule);
+      expect(group, `"${label}": rule "${rule}" should have a group in scan results`).toBeDefined();
+      const violation = group!.violations.find((v) => v.index === index);
+      expect(
+        violation,
+        `"${label}": should appear as violation for rule "${rule}" in scan results`,
+      ).toBeDefined();
+    }
+  });
+
+  test('expect-ok cases do not produce warnings for their rule via groupByRule', async ({
+    page,
+  }) => {
+    await page.goto(TEST_HTML);
+
+    const okCases = page.locator('.case.expect-ok[data-rule]');
+    const okCount = await okCases.count();
+    expect(okCount).toBeGreaterThan(0);
+
+    const scanElements: ScanElementData[] = [];
+    const caseRules: { index: number; rule: string; label: string }[] = [];
+
+    for (let i = 0; i < okCount; i++) {
+      const caseEl = okCases.nth(i);
+      const rule = await caseEl.getAttribute('data-rule');
+      if (!rule || rule === 'none') continue;
+
+      const target = caseEl.locator('[data-target]');
+      const label = (await caseEl.locator('.label').textContent()) ?? `(index ${i})`;
+      const data = await extractElementData(target);
+
+      scanElements.push({
+        index: i,
+        selector: `ok-case-${i}`,
+        tagName: data.tagName,
+        id: data.id,
+        classList: data.classList,
+        computedStyles: data.computedStyles,
+        parent: data.parent,
+      });
+      caseRules.push({ index: i, rule, label });
+    }
+
+    const groups = groupByRule(scanElements);
+
+    // No expect-ok case should appear in the group for its data-rule
+    for (const { index, rule, label } of caseRules) {
+      const group = groups.find((g) => g.ruleId === rule);
+      if (!group) continue; // No group for this rule at all — OK
+      const violation = group.violations.find((v) => v.index === index);
+      expect(
+        violation,
+        `"${label}": should NOT appear as violation for rule "${rule}" in scan results`,
+      ).toBeUndefined();
+    }
+  });
+});

--- a/src/sidebar/hooks/__tests__/usePageScan.hook.test.tsx
+++ b/src/sidebar/hooks/__tests__/usePageScan.hook.test.tsx
@@ -39,6 +39,7 @@ function makeChunkResult(
     id: '',
     classList: [],
     computedStyles: makeBaseStyles(overrides),
+    parent: null,
   }));
   return { results, total };
 }

--- a/src/sidebar/hooks/__tests__/usePageScan.test.ts
+++ b/src/sidebar/hooks/__tests__/usePageScan.test.ts
@@ -34,6 +34,7 @@ function makeScanElement(
       flexWrap: 'nowrap',
       ...styles,
     },
+    parent: null,
   };
 }
 

--- a/src/sidebar/hooks/usePageScan.ts
+++ b/src/sidebar/hooks/usePageScan.ts
@@ -1,6 +1,9 @@
 import { useState, useCallback, useRef } from 'react';
-import { getAllRequiredProperties } from '../../rules/registry.ts';
-import { generateStyleExtractFragment } from '../../rules/css-properties.ts';
+import { getAllRequiredParentProperties, getAllRequiredProperties } from '../../rules/registry.ts';
+import {
+  generateParentStyleExtractFragment,
+  generateStyleExtractFragment,
+} from '../../rules/css-properties.ts';
 import type { ScanStatus, ScanElementData, ScanGroup, ScanProgress } from '../types.ts';
 import { groupByRule } from '../utils/group-by-rule.ts';
 
@@ -8,6 +11,21 @@ const CHUNK_SIZE = 200;
 const MAX_ELEMENTS = 10_000;
 
 function makeScanScript(offset: number, limit: number): string {
+  const parentFragment = generateParentStyleExtractFragment();
+  const parentBlock = parentFragment
+    ? `
+    var pe = el.parentElement;
+    var parent = null;
+    if (pe) {
+      var pcs = getComputedStyle(pe);
+      parent = {
+        computedStyles: {
+              ${parentFragment}
+        }
+      };
+    }`
+    : '';
+
   return `(function(offset, limit) {
   var SKIP = {SCRIPT:1,STYLE:1,NOSCRIPT:1,TEMPLATE:1,BASE:1,LINK:1,META:1};
   if (!document.body) return { results: [], total: 0 };
@@ -23,7 +41,7 @@ function makeScanScript(offset: number, limit: number): string {
     var sel = el.tagName.toLowerCase();
     if (el.id) sel += '#' + CSS.escape(el.id);
     var cl = el.classList;
-    for (var j = 0; j < cl.length && j < 3; j++) sel += '.' + CSS.escape(cl[j]);
+    for (var j = 0; j < cl.length && j < 3; j++) sel += '.' + CSS.escape(cl[j]);${parentBlock}
     results.push({
       index: i,
       selector: sel,
@@ -32,7 +50,8 @@ function makeScanScript(offset: number, limit: number): string {
       classList: Array.from(el.classList),
       computedStyles: {
         ${generateStyleExtractFragment()}
-      }
+      },
+      parent: ${parentFragment ? 'parent' : 'null'}
     });
   }
   return { results: results, total: total };
@@ -49,7 +68,20 @@ function isScanElementData(v: unknown): v is ScanElementData {
   const cs = o['computedStyles'];
   if (typeof cs !== 'object' || cs === null) return false;
   const styles = cs as Record<string, unknown>;
-  return getAllRequiredProperties().every((key) => typeof styles[key] === 'string');
+  if (!getAllRequiredProperties().every((key) => typeof styles[key] === 'string')) return false;
+
+  const parent = o['parent'];
+  if (parent !== null) {
+    if (typeof parent !== 'object' || parent === undefined) return false;
+    const p = parent as Record<string, unknown>;
+    const pcs = p['computedStyles'];
+    if (typeof pcs !== 'object' || pcs === null) return false;
+    const parentStyles = pcs as Record<string, unknown>;
+    if (!getAllRequiredParentProperties().every((key) => typeof parentStyles[key] === 'string'))
+      return false;
+  }
+
+  return true;
 }
 
 interface ChunkResult {

--- a/src/sidebar/types.ts
+++ b/src/sidebar/types.ts
@@ -10,6 +10,7 @@ export interface ScanElementData {
   id: string;
   classList: string[];
   computedStyles: Record<string, string>;
+  parent: { computedStyles: Record<string, string> } | null;
 }
 
 export interface ScanViolation {

--- a/src/sidebar/utils/group-by-rule.ts
+++ b/src/sidebar/utils/group-by-rule.ts
@@ -6,15 +6,12 @@ export function groupByRule(elements: ScanElementData[]): ScanGroup[] {
   const map = new Map<RuleId, ScanViolation[]>();
 
   for (const el of elements) {
-    // TODO: Page scan does not collect parent context. Rules using
-    // isFlexItem/isGridItem will not fire here. When a parent-dependent
-    // rule is added, extend makeScanScript to collect parentElement styles.
     const elementData: ElementData = {
       tagName: el.tagName,
       id: el.id,
       classList: el.classList,
       computedStyles: el.computedStyles,
-      parent: null,
+      parent: el.parent,
     };
     const warnings = analyzeElement(elementData);
     if (warnings.length === 0) continue;


### PR DESCRIPTION
## Summary

- **Fix false positives in page scan**: `makeScanScript` now collects parent element computed styles using `generateParentStyleExtractFragment()`, the same registry-driven approach used by `buildEvalScript`
- **Enable parent-dependent rules**: `item-no-self-align`, `item-no-order`, and `static-no-z-index` now correctly detect flex/grid parent context during page scans instead of always treating `parent` as `null`
- **Add validation**: `isScanElementData` validates the `parent` field structure, matching the pattern in `isElementData`
- **Add E2E tests**: New `page-scan-rules.test.ts` verifies that `groupByRule` with parent context matches per-element analysis for all test cases in `test.html`

| Decision | Rationale |
|----------|-----------|
| Reuse `generateParentStyleExtractFragment()` | Keeps parent property list in sync with rule registry automatically |
| `parent: null` fallback when no parent rules exist | `generateParentStyleExtractFragment()` returns `null` when no rules declare `requiredParentProperties` |

## Test plan

- [x] `pnpm test` — 223 unit tests pass
- [x] `pnpm build` — TypeScript + Vite build succeeds
- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `pnpm test:e2e` — 11 E2E tests pass (3 new page scan tests)
- [ ] Load extension in Chrome DevTools, run page scan on a page with flex/grid layouts, verify no false positives on flex/grid children

🤖 Generated with [Claude Code](https://claude.com/claude-code)