### PR TITLE
feat: add item-no-flex-props rule

### DIFF
--- a/e2e/integration/rules-against-real-styles.test.ts
+++ b/e2e/integration/rules-against-real-styles.test.ts
@@ -9,7 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const TEST_HTML = `file://${path.resolve(__dirname, '../../examples/test.html')}`;
 
 // Update this when adding/removing test cases in test.html.
-const EXPECTED_CASE_COUNT = 60;
+const EXPECTED_CASE_COUNT = 67;
 
 const registeredRuleIds = new Set(getRules().map((r) => r.id));
 

--- a/examples/test.html
+++ b/examples/test.html
@@ -365,6 +365,57 @@
       <div data-target style="margin-top: 20px">block div with margin-top</div>
     </div>
 
+    <!-- ===== item-no-flex-props: flex item props on children of non-flex containers ===== -->
+    <h2>item-no-flex-props: flex item props on children of non-flex containers</h2>
+
+    <h3>Should warn</h3>
+    <div class="case expect-warn" data-rule="item-no-flex-props">
+      <div class="label label-warn">item-no-flex-props warn: flex-grow on block child</div>
+      <div>
+        <div data-target style="flex-grow: 1">flex-grow: 1 on child of block parent</div>
+      </div>
+    </div>
+    <div class="case expect-warn" data-rule="item-no-flex-props">
+      <div class="label label-warn">item-no-flex-props warn: flex-shrink on block child</div>
+      <div>
+        <div data-target style="flex-shrink: 0">flex-shrink: 0 on child of block parent</div>
+      </div>
+    </div>
+    <div class="case expect-warn" data-rule="item-no-flex-props">
+      <div class="label label-warn">item-no-flex-props warn: flex-basis on block child</div>
+      <div>
+        <div data-target style="flex-basis: 100px">flex-basis: 100px on child of block parent</div>
+      </div>
+    </div>
+    <div class="case expect-warn" data-rule="item-no-flex-props">
+      <div class="label label-warn">item-no-flex-props warn: flex-grow on grid child</div>
+      <div style="display: grid">
+        <div data-target style="flex-grow: 1">flex-grow: 1 on child of grid parent</div>
+      </div>
+    </div>
+
+    <h3>Should NOT warn</h3>
+    <div class="case expect-ok" data-rule="item-no-flex-props">
+      <div class="label label-ok">item-no-flex-props ok: flex-grow on flex child</div>
+      <div style="display: flex">
+        <div data-target style="flex-grow: 1">flex-grow: 1 on child of flex parent</div>
+      </div>
+    </div>
+    <div class="case expect-ok" data-rule="item-no-flex-props">
+      <div class="label label-ok">item-no-flex-props ok: flex-grow on inline-flex child</div>
+      <div style="display: inline-flex">
+        <div data-target style="flex-grow: 1">flex-grow: 1 on child of inline-flex parent</div>
+      </div>
+    </div>
+    <div class="case expect-ok" data-rule="item-no-flex-props">
+      <div class="label label-ok">item-no-flex-props ok: default values on block child</div>
+      <div>
+        <div data-target style="flex-grow: 0; flex-shrink: 1; flex-basis: auto">
+          default flex values on child of block parent
+        </div>
+      </div>
+    </div>
+
     <!-- ===== item-no-order: order on non-flex/grid items ===== -->
     <h2>item-no-order: order on non-flex/grid items</h2>
 

--- a/src/rules/__tests__/helpers/make-element.ts
+++ b/src/rules/__tests__/helpers/make-element.ts
@@ -36,6 +36,9 @@ export const DEFAULT_COMPUTED_STYLES: ElementData['computedStyles'] = {
   willChange: 'auto',
   flexDirection: 'row',
   flexWrap: 'nowrap',
+  flexGrow: '0',
+  flexShrink: '1',
+  flexBasis: 'auto',
 };
 
 /** Create a test ElementData with overrides and optional tagName / parent. */

--- a/src/rules/__tests__/non-flex-child-props.test.ts
+++ b/src/rules/__tests__/non-flex-child-props.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { checkItemNoFlexProps } from '../non-flex-child-props.ts';
+import { createRuleContext } from '../context.ts';
+import type { ElementData } from '../types.ts';
+import { makeElement as _makeElement } from './helpers/make-element.ts';
+
+function makeElement(
+  styles: Partial<ElementData['computedStyles']>,
+  parent: ElementData['parent'] = { computedStyles: { display: 'block' } },
+): ElementData {
+  return _makeElement(styles, parent);
+}
+
+describe('item-no-flex-props', () => {
+  it('warns when flex-grow is set on child of block container', () => {
+    const warnings = checkItemNoFlexProps(createRuleContext(makeElement({ flexGrow: '1' })));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].ruleId).toBe('item-no-flex-props');
+    expect(warnings[0].property).toBe('flex-grow');
+    expect(warnings[0].details).toContain('block');
+  });
+
+  it('warns when flex-shrink is set to non-default on child of block container', () => {
+    const warnings = checkItemNoFlexProps(createRuleContext(makeElement({ flexShrink: '0' })));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].property).toBe('flex-shrink');
+  });
+
+  it('warns when flex-basis is set on child of block container', () => {
+    const warnings = checkItemNoFlexProps(createRuleContext(makeElement({ flexBasis: '100px' })));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].property).toBe('flex-basis');
+  });
+
+  it('warns for multiple non-default flex properties at once', () => {
+    const warnings = checkItemNoFlexProps(
+      createRuleContext(makeElement({ flexGrow: '1', flexShrink: '0', flexBasis: '100px' })),
+    );
+    expect(warnings).toHaveLength(3);
+  });
+
+  it('warns on grid items (flex properties are flex-specific, not grid)', () => {
+    const warnings = checkItemNoFlexProps(
+      createRuleContext(makeElement({ flexGrow: '1' }, { computedStyles: { display: 'grid' } })),
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].property).toBe('flex-grow');
+  });
+
+  it('warns on inline-grid items', () => {
+    const warnings = checkItemNoFlexProps(
+      createRuleContext(
+        makeElement({ flexGrow: '1' }, { computedStyles: { display: 'inline-grid' } }),
+      ),
+    );
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('skips flex items (parent is flex)', () => {
+    const warnings = checkItemNoFlexProps(
+      createRuleContext(makeElement({ flexGrow: '1' }, { computedStyles: { display: 'flex' } })),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('skips flex items (parent is inline-flex)', () => {
+    const warnings = checkItemNoFlexProps(
+      createRuleContext(
+        makeElement({ flexGrow: '1' }, { computedStyles: { display: 'inline-flex' } }),
+      ),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('skips when all values are defaults', () => {
+    const warnings = checkItemNoFlexProps(
+      createRuleContext(makeElement({ flexGrow: '0', flexShrink: '1', flexBasis: 'auto' })),
+    );
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('skips when parent is null (unknown parent context)', () => {
+    const warnings = checkItemNoFlexProps(createRuleContext(makeElement({ flexGrow: '1' }, null)));
+    expect(warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/engine.ts
+++ b/src/rules/engine.ts
@@ -10,6 +10,7 @@ import './order.ts';
 import './block-vertical-align.ts';
 import './static-z-index.ts';
 import './flex-container-props.ts';
+import './non-flex-child-props.ts';
 
 import type { ElementData, Warning } from './types.ts';
 import { createRuleContext } from './context.ts';

--- a/src/rules/non-flex-child-props.ts
+++ b/src/rules/non-flex-child-props.ts
@@ -1,0 +1,45 @@
+import type { RuleDescriptor, Warning } from './types.ts';
+import { registerRule } from './registry.ts';
+
+const FLEX_CHILD_PROPERTIES = [
+  { key: 'flexGrow', cssName: 'flex-grow', defaultValue: '0' },
+  { key: 'flexShrink', cssName: 'flex-shrink', defaultValue: '1' },
+  { key: 'flexBasis', cssName: 'flex-basis', defaultValue: 'auto' },
+] as const;
+
+const rule: RuleDescriptor = {
+  id: 'item-no-flex-props',
+  label: 'flex item props on non-flex child',
+  requiredProperties: FLEX_CHILD_PROPERTIES.map((p) => p.key),
+  requiredParentProperties: ['display'],
+  check(ctx): Warning[] {
+    if (!ctx.parentStyles) return [];
+    // flex-grow/flex-shrink/flex-basis only apply to flex items.
+    // Unlike order/align-self which apply to both flex and grid items,
+    // these properties are flex-specific, so grid items are NOT excluded.
+    if (ctx.isFlexItem) return [];
+
+    const parentDisplay = ctx.parentStyles.display ?? 'block';
+
+    return FLEX_CHILD_PROPERTIES.flatMap(({ key, cssName, defaultValue }) => {
+      const value = ctx.styles[key];
+      if (value === defaultValue) return [];
+
+      return [
+        {
+          ruleId: 'item-no-flex-props',
+          property: cssName,
+          severity: 'warning',
+          title: `${cssName} has no effect`,
+          details: `${cssName} is "${value}" but parent display is "${parentDisplay}". Flex item properties only apply to children of flex containers.`,
+          suggestion:
+            'Set display: flex or display: inline-flex on the parent element, or remove this property.',
+        },
+      ];
+    });
+  },
+};
+
+registerRule(rule);
+
+export const checkItemNoFlexProps = rule.check;

--- a/src/sidebar/hooks/__tests__/useSelectedElement.test.ts
+++ b/src/sidebar/hooks/__tests__/useSelectedElement.test.ts
@@ -42,6 +42,9 @@ const validData = {
     willChange: 'auto',
     flexDirection: 'row',
     flexWrap: 'nowrap',
+    flexGrow: '0',
+    flexShrink: '1',
+    flexBasis: 'auto',
   },
   parent: null,
 };
@@ -170,6 +173,9 @@ describe('isElementData', () => {
       'willChange',
       'flexDirection',
       'flexWrap',
+      'flexGrow',
+      'flexShrink',
+      'flexBasis',
     ];
     for (const key of requiredKeys) {
       const styles = { ...validData.computedStyles };


### PR DESCRIPTION
## Summary

- Add `item-no-flex-props` rule that detects `flex-grow`, `flex-shrink`, and `flex-basis` on elements whose parent is not a flex container
- These properties are flex-specific (unlike `order`/`align-self` which apply to both flex and grid items), so grid children also trigger warnings
- Rule ID follows the `<target>-no-<qualifier>` naming convention (`item-no-flex-props`)
- Gracefully skips when parent data is unavailable

Closes #16

## Test plan

- [x] `pnpm build` — type-check and bundle pass
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm test` — 300/300 unit tests pass (10 new for this rule)
- [x] `pnpm test:e2e` — 11/11 Playwright tests pass (7 new test cases in test.html)
- [x] Reviewed by 5 specialized agents (code-reviewer, comment-analyzer, silent-failure-hunter, type-design-analyzer, pr-test-analyzer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)