### PR TITLE
chore: upgrade Node.js from 22 to 24

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,3 @@
 [tools]
-node = "22"
+node = "24"
 pnpm = "10"


### PR DESCRIPTION
## Summary
- Upgrade Node.js from 22 (maintenance) to 24 (Active LTS) in `.mise.toml`
- Node 22 entered maintenance mode; Node 24 is the current Active LTS
- Build and all 473 unit tests pass on v24.12.0

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — 38 test files, 473 tests all pass
- [ ] `pnpm test:e2e` — verify browser integration tests