### PR TITLE
chore: sync version between package.json and manifest.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-noop-checker",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "private": true,
   "description": "Chrome DevTools extension that detects no-op CSS properties",
   "keywords": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,30 @@
 import { defineConfig } from 'vite';
+import type { Plugin } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
+function manifestVersion(): Plugin {
+  return {
+    name: 'manifest-version',
+    generateBundle(_, bundle) {
+      const asset = bundle['manifest.json'];
+      if (!asset || asset.type !== 'asset') return;
+
+      const { version } = JSON.parse(readFileSync(resolve(__dirname, 'package.json'), 'utf-8'));
+      const manifest = JSON.parse(asset.source as string);
+      manifest.version = version;
+      asset.source = JSON.stringify(manifest, null, 2) + '\n';
+    },
+  };
+}
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), manifestVersion()],
   base: '',
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary

- Make `package.json` the single source of truth for the extension version
- Add a Vite plugin that injects the version into `manifest.json` at build time via the `generateBundle` hook
- Update `package.json` version from `0.0.0` to `0.1.0` to match `manifest.json`

| Before | After |
|---|---|
| `package.json`: `0.0.0`, `manifest.json`: `0.1.0` | Both: `0.1.0` (package.json drives manifest.json) |

Closes #101

## Test plan

- [x] `pnpm build` — build succeeds, `dist/manifest.json` contains `0.1.0`
- [x] `pnpm test` — all 689 tests pass
- [x] `pnpm lint` — no errors