### PR TITLE
docs: sync documentation with current codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
 
 ```
 src/
-  rules/           19 detection rules + engine, registry, context, types
-  sidebar/         DevTools sidebar React UI (components, hooks)
+  rules/           Detection rules + engine, registry, context, types
+  sidebar/         DevTools sidebar React UI (see src/sidebar/ for details)
   devtools.ts      Extension entrypoint — creates the sidebar pane
 e2e/
   helpers/         Playwright extraction helpers (shared with MCP server)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,8 +135,7 @@ New rules are automatically covered when test cases are added to `test.html` wit
 
 ### Sidebar UI (`src/sidebar/`)
 
-- `hooks/useSelectedElement.ts` — Chrome DevTools bridge: `$0` eval with 150ms debounce, `requestIdRef` stale response guard, `isElementData()` runtime validation
-- `components/` — PanelHeader, WarningList, WarningCard, PanelFooter
+React app rendered in the DevTools sidebar pane. See `src/sidebar/components/` and `src/sidebar/hooks/` for the full list.
 
 ### Build Constraints
 

--- a/README.md
+++ b/README.md
@@ -9,39 +9,16 @@ Chrome DevTools (Elements sidebar) extension that detects CSS properties that cu
 
 - **Selected-element mode** — inspects the currently selected element in DevTools
 - **Full-page scan** — scans all elements on a page for violations
-- **19 detection rules** — categorized by context (inline, block, container, item, static, overflow, etc.)
+- **Detection rules** — categorized by context (inline, block, container, item, static, positioned, overflow, etc.)
 - **MCP server** — exposes rules as tools for AI-assisted analysis via Playwright
 - **Actionable warnings** — each warning includes a title, explanation, and fix suggestion
 
 ## Detection Rules
 
-| Rule ID                             | Detects                                                 |
-| ----------------------------------- | ------------------------------------------------------- |
-| **Inline**                          |                                                         |
-| `inline-no-dimensions`              | `width`/`height` on non-replaced inline elements        |
-| `inline-no-vertical-margin`         | Vertical `margin` on inline elements                    |
-| **Block**                           |                                                         |
-| `block-no-vertical-align`           | `vertical-align` on block-level elements                |
-| **Container**                       |                                                         |
-| `container-no-align`                | `align-items`/`justify-content` outside flex/grid       |
-| `container-no-flex-props`           | `flex-direction`/`flex-wrap` on non-flex containers     |
-| `container-no-gap`                  | `gap`/`row-gap`/`column-gap` outside flex/grid          |
-| `container-no-grid-props`           | Grid container properties on non-grid containers        |
-| `container-no-place`                | `place-items`/`place-content` outside flex/grid         |
-| **Item**                            |                                                         |
-| `item-no-flex-props`                | Flex item properties on non-flex children               |
-| `item-no-float`                     | `float` on flex/grid items                              |
-| `item-no-grid-props`                | Grid item properties on non-grid children               |
-| `item-no-order`                     | `order` on non-flex/grid items                          |
-| `item-no-self-align`                | `align-self` on non-flex/grid items                     |
-| **Static position**                 |                                                         |
-| `static-no-offset`                  | `top`/`right`/`bottom`/`left` on `position: static`     |
-| `static-no-z-index`                 | `z-index` outside stacking context                      |
-| **Other**                           |                                                         |
-| `nonfloat-no-shape-outside`         | `shape-outside` on non-floated elements                 |
-| `nonreplaced-no-object-fit`         | `object-fit`/`object-position` on non-replaced elements |
-| `visible-overflow-no-resize`        | `resize` when overflow is visible                       |
-| `visible-overflow-no-text-overflow` | `text-overflow` when overflow is visible                |
+Rules are organized by context:
+**Inline** · **Block** · **Container** · **Item** · **Static** · **Positioned** · **Overflow** · **Other**
+
+Rule IDs follow Stylelint's `thing-no-qualifier` convention. See `src/rules/` for the full list, or run `list_rules` via the MCP server.
 
 ## Quick Start
 
@@ -51,7 +28,7 @@ pnpm build
 ```
 
 1. Open `chrome://extensions` and enable Developer mode.
-2. Click **Load unpacked** and select this project directory.
+2. Click **Load unpacked** and select the `dist/` directory.
 3. Open DevTools on any page → **Elements** tab → **CSS Noop** sidebar pane.
 
 For development with watch-mode rebuilds:


### PR DESCRIPTION
## Summary

- Remove rule table from README.md — rule IDs are self-descriptive (`thing-no-qualifier`) and the table required manual updates on every rule addition
- Remove hardcoded rule counts from README.md and AGENTS.md for the same reason
- Simplify sidebar UI sections in CLAUDE.md and AGENTS.md — reference directories instead of listing individual files
- Fix Load unpacked target to `dist/` in README.md

## Test plan

- [ ] Verify README.md renders correctly on GitHub
- [ ] Verify CLAUDE.md and AGENTS.md are accurate against current codebase