### PR TITLE
docs: add contents-no-position to README Detected Patterns table

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ CSS Noop Checker finds CSS properties that have **no visible effect** on the ele
 | Rule                                                                        | Description                                        |
 | --------------------------------------------------------------------------- | -------------------------------------------------- |
 | [`contents-no-box-props`](./src/rules/contents-no-box-props.ts)             | box properties on display:contents                 |
+| [`contents-no-position`](./src/rules/contents-no-position.ts)               | positioning on display:contents                    |
 | [`multicol-no-column-rule`](./src/rules/multicol-no-column-rule.ts)         | column-rule/column-fill on non-multicol container  |
 | [`nonfloat-no-shape-outside`](./src/rules/nonfloat-no-shape-outside.ts)     | shape-outside on non-floated element               |
 | [`nonreplaced-no-aspect-ratio`](./src/rules/nonreplaced-no-aspect-ratio.ts) | aspect-ratio on inline non-replaced element        |


### PR DESCRIPTION
## Summary
- Add missing `contents-no-position` entry to the "Other" section of the Detected Patterns table in README.md
- The rule was fully implemented (source, docs, unit tests, e2e tests) but missing from the table — violating CLAUDE.md New Rule Checklist step 7

Closes #165

## Test plan
- [x] Verify link target `./src/rules/contents-no-position.ts` exists and is correct
- [x] Verify alphabetical order (between `contents-no-box-props` and `multicol-no-column-rule`)
- [x] Verify description matches rule label and table conventions (plain text, no backticks)
- [x] `pnpm lint` passes
- [x] `pnpm fmt:check` passes