### PR TITLE
test: improve visual clarity of test.html warn cases

### DIFF
--- a/examples/test.html
+++ b/examples/test.html
@@ -139,13 +139,13 @@
       <div class="label label-warn">
         block-no-vertical-align warn: div with vertical-align: middle
       </div>
-      <div data-target style="vertical-align: middle">
+      <div data-target style="vertical-align: middle; height: 60px; background: #f0f0f0">
         Block element with vertical-align: middle (no effect)
       </div>
     </div>
     <div class="case expect-warn" data-rule="block-no-vertical-align">
       <div class="label label-warn">block-no-vertical-align warn: div with vertical-align: top</div>
-      <div data-target style="vertical-align: top">
+      <div data-target style="vertical-align: top; height: 60px; background: #f0f0f0">
         Block element with vertical-align: top (no effect)
       </div>
     </div>


### PR DESCRIPTION
## Summary

- Add height, background colors, and descriptive text to container-no-* warn cases so no-op effects are visually apparent
- Add background colors, padding, sibling elements to item-no-* warn cases for visual contrast
- Wrap absolute/fixed-positioned test elements in visible containers to prevent off-screen rendering
- Add visual context to block-no-vertical-align plain-div warn cases

Visual-only improvements — no test case additions/removals, no rule logic changes, `EXPECTED_CASE_COUNT` unchanged at 407.

## Test plan

- [x] `pnpm test` — 964 tests pass
- [x] `pnpm test:e2e` — 17 tests pass
- [x] `pnpm lint` — no errors
- [x] `pnpm fmt:check` — no errors
- [x] Verified `EXPECTED_CASE_COUNT` unchanged
- [ ] Visual inspection of test.html in browser