### PR TITLE
fix: add backdropFilter empty-string guard in isStackingContext

### DIFF
--- a/src/rules/stacking-context.ts
+++ b/src/rules/stacking-context.ts
@@ -33,7 +33,8 @@ export function isStackingContext(styles: Record<string, string>): boolean {
   if (filter !== undefined && filter !== 'none') return true;
 
   const backdropFilter = styles['backdropFilter'];
-  if (backdropFilter !== undefined && backdropFilter !== 'none') return true;
+  if (backdropFilter !== undefined && backdropFilter !== 'none' && backdropFilter !== '')
+    return true;
 
   const perspective = styles['perspective'];
   if (perspective !== undefined && perspective !== 'none') return true;


### PR DESCRIPTION
## Summary
- Add empty-string guard (`&& backdropFilter !== ''`) to `backdropFilter` check in `isStackingContext()` for defensive consistency
- Matches the pattern already used for `mask` property on the same file
- Closes #173

## Test plan
- [x] All 964 unit tests pass (`pnpm test`)
- [x] Lint clean (`pnpm lint`)
- [x] Formatted with oxfmt (`pnpm fmt`)