### PR TITLE
refactor: rename isDefaultMarginValue to isZeroPx

### DIFF
--- a/src/rules/contents-no-box-props.ts
+++ b/src/rules/contents-no-box-props.ts
@@ -1,5 +1,5 @@
 import { type RuleDescriptor, type Warning, createWarning } from './types.ts';
-import { isDefaultInlineSizeValue, isDefaultMarginValue } from './context.ts';
+import { isDefaultInlineSizeValue, isZeroPx } from './context.ts';
 import { registerRule } from './registry.ts';
 
 const RULE_ID = 'contents-no-box-props' as const;
@@ -87,120 +87,74 @@ const rule: RuleDescriptor = {
     // Sizing dedup
     const skipWidth = bothNonDefault(s.width, s.inlineSize, isDefaultInlineSizeValue);
     const skipHeight = bothNonDefault(s.height, s.blockSize, isDefaultInlineSizeValue);
-    const skipMinWidth = bothNonDefault(s.minWidth, s.minInlineSize, isDefaultMarginValue);
+    const skipMinWidth = bothNonDefault(s.minWidth, s.minInlineSize, isZeroPx);
     const skipMaxWidth = bothNonDefault(s.maxWidth, s.maxInlineSize, isDefaultNoneValue);
-    const skipMinHeight = bothNonDefault(s.minHeight, s.minBlockSize, isDefaultMarginValue);
+    const skipMinHeight = bothNonDefault(s.minHeight, s.minBlockSize, isZeroPx);
     const skipMaxHeight = bothNonDefault(s.maxHeight, s.maxBlockSize, isDefaultNoneValue);
 
     // Margin dedup
-    const skipMarginTop = bothNonDefault(s.marginTop, s.marginBlockStart, isDefaultMarginValue);
-    const skipMarginBottom = bothNonDefault(s.marginBottom, s.marginBlockEnd, isDefaultMarginValue);
-    const skipMarginRight = bothNonDefault(s.marginRight, s.marginInlineEnd, isDefaultMarginValue);
-    const skipMarginLeft = bothNonDefault(s.marginLeft, s.marginInlineStart, isDefaultMarginValue);
+    const skipMarginTop = bothNonDefault(s.marginTop, s.marginBlockStart, isZeroPx);
+    const skipMarginBottom = bothNonDefault(s.marginBottom, s.marginBlockEnd, isZeroPx);
+    const skipMarginRight = bothNonDefault(s.marginRight, s.marginInlineEnd, isZeroPx);
+    const skipMarginLeft = bothNonDefault(s.marginLeft, s.marginInlineStart, isZeroPx);
 
     // Padding dedup
-    const skipPaddingTop = bothNonDefault(s.paddingTop, s.paddingBlockStart, isDefaultMarginValue);
-    const skipPaddingBottom = bothNonDefault(
-      s.paddingBottom,
-      s.paddingBlockEnd,
-      isDefaultMarginValue,
-    );
-    const skipPaddingRight = bothNonDefault(
-      s.paddingRight,
-      s.paddingInlineEnd,
-      isDefaultMarginValue,
-    );
-    const skipPaddingLeft = bothNonDefault(
-      s.paddingLeft,
-      s.paddingInlineStart,
-      isDefaultMarginValue,
-    );
+    const skipPaddingTop = bothNonDefault(s.paddingTop, s.paddingBlockStart, isZeroPx);
+    const skipPaddingBottom = bothNonDefault(s.paddingBottom, s.paddingBlockEnd, isZeroPx);
+    const skipPaddingRight = bothNonDefault(s.paddingRight, s.paddingInlineEnd, isZeroPx);
+    const skipPaddingLeft = bothNonDefault(s.paddingLeft, s.paddingInlineStart, isZeroPx);
 
     // Border-width dedup
-    const skipBorderTop = bothNonDefault(
-      s.borderTopWidth,
-      s.borderBlockStartWidth,
-      isDefaultMarginValue,
-    );
-    const skipBorderBottom = bothNonDefault(
-      s.borderBottomWidth,
-      s.borderBlockEndWidth,
-      isDefaultMarginValue,
-    );
-    const skipBorderRight = bothNonDefault(
-      s.borderRightWidth,
-      s.borderInlineEndWidth,
-      isDefaultMarginValue,
-    );
-    const skipBorderLeft = bothNonDefault(
-      s.borderLeftWidth,
-      s.borderInlineStartWidth,
-      isDefaultMarginValue,
-    );
+    const skipBorderTop = bothNonDefault(s.borderTopWidth, s.borderBlockStartWidth, isZeroPx);
+    const skipBorderBottom = bothNonDefault(s.borderBottomWidth, s.borderBlockEndWidth, isZeroPx);
+    const skipBorderRight = bothNonDefault(s.borderRightWidth, s.borderInlineEndWidth, isZeroPx);
+    const skipBorderLeft = bothNonDefault(s.borderLeftWidth, s.borderInlineStartWidth, isZeroPx);
 
     const boxProps: Array<[string, string, (v: string) => boolean, string, boolean?]> = [
       // Physical sizing (skip when logical counterpart is also non-default)
       ['width', s.width, isDefaultInlineSizeValue, BOX_SUGGESTION, skipWidth],
       ['height', s.height, isDefaultInlineSizeValue, BOX_SUGGESTION, skipHeight],
-      ['min-width', s.minWidth, isDefaultMarginValue, BOX_SUGGESTION, skipMinWidth],
+      ['min-width', s.minWidth, isZeroPx, BOX_SUGGESTION, skipMinWidth],
       ['max-width', s.maxWidth, isDefaultNoneValue, BOX_SUGGESTION, skipMaxWidth],
-      ['min-height', s.minHeight, isDefaultMarginValue, BOX_SUGGESTION, skipMinHeight],
+      ['min-height', s.minHeight, isZeroPx, BOX_SUGGESTION, skipMinHeight],
       ['max-height', s.maxHeight, isDefaultNoneValue, BOX_SUGGESTION, skipMaxHeight],
       // Logical sizing
       ['inline-size', s.inlineSize, isDefaultInlineSizeValue, BOX_SUGGESTION],
       ['block-size', s.blockSize, isDefaultInlineSizeValue, BOX_SUGGESTION],
-      ['min-inline-size', s.minInlineSize, isDefaultMarginValue, BOX_SUGGESTION],
+      ['min-inline-size', s.minInlineSize, isZeroPx, BOX_SUGGESTION],
       ['max-inline-size', s.maxInlineSize, isDefaultNoneValue, BOX_SUGGESTION],
-      ['min-block-size', s.minBlockSize, isDefaultMarginValue, BOX_SUGGESTION],
+      ['min-block-size', s.minBlockSize, isZeroPx, BOX_SUGGESTION],
       ['max-block-size', s.maxBlockSize, isDefaultNoneValue, BOX_SUGGESTION],
       // Physical margin (skip when logical counterpart is also non-default)
-      ['margin-top', s.marginTop, isDefaultMarginValue, BOX_SUGGESTION, skipMarginTop],
-      ['margin-right', s.marginRight, isDefaultMarginValue, BOX_SUGGESTION, skipMarginRight],
-      ['margin-bottom', s.marginBottom, isDefaultMarginValue, BOX_SUGGESTION, skipMarginBottom],
-      ['margin-left', s.marginLeft, isDefaultMarginValue, BOX_SUGGESTION, skipMarginLeft],
+      ['margin-top', s.marginTop, isZeroPx, BOX_SUGGESTION, skipMarginTop],
+      ['margin-right', s.marginRight, isZeroPx, BOX_SUGGESTION, skipMarginRight],
+      ['margin-bottom', s.marginBottom, isZeroPx, BOX_SUGGESTION, skipMarginBottom],
+      ['margin-left', s.marginLeft, isZeroPx, BOX_SUGGESTION, skipMarginLeft],
       // Logical margin
-      ['margin-block-start', s.marginBlockStart, isDefaultMarginValue, BOX_SUGGESTION],
-      ['margin-block-end', s.marginBlockEnd, isDefaultMarginValue, BOX_SUGGESTION],
-      ['margin-inline-start', s.marginInlineStart, isDefaultMarginValue, BOX_SUGGESTION],
-      ['margin-inline-end', s.marginInlineEnd, isDefaultMarginValue, BOX_SUGGESTION],
+      ['margin-block-start', s.marginBlockStart, isZeroPx, BOX_SUGGESTION],
+      ['margin-block-end', s.marginBlockEnd, isZeroPx, BOX_SUGGESTION],
+      ['margin-inline-start', s.marginInlineStart, isZeroPx, BOX_SUGGESTION],
+      ['margin-inline-end', s.marginInlineEnd, isZeroPx, BOX_SUGGESTION],
       // Physical padding (skip when logical counterpart is also non-default)
-      ['padding-top', s.paddingTop, isDefaultMarginValue, BOX_SUGGESTION, skipPaddingTop],
-      ['padding-right', s.paddingRight, isDefaultMarginValue, BOX_SUGGESTION, skipPaddingRight],
-      ['padding-bottom', s.paddingBottom, isDefaultMarginValue, BOX_SUGGESTION, skipPaddingBottom],
-      ['padding-left', s.paddingLeft, isDefaultMarginValue, BOX_SUGGESTION, skipPaddingLeft],
+      ['padding-top', s.paddingTop, isZeroPx, BOX_SUGGESTION, skipPaddingTop],
+      ['padding-right', s.paddingRight, isZeroPx, BOX_SUGGESTION, skipPaddingRight],
+      ['padding-bottom', s.paddingBottom, isZeroPx, BOX_SUGGESTION, skipPaddingBottom],
+      ['padding-left', s.paddingLeft, isZeroPx, BOX_SUGGESTION, skipPaddingLeft],
       // Logical padding
-      ['padding-block-start', s.paddingBlockStart, isDefaultMarginValue, BOX_SUGGESTION],
-      ['padding-block-end', s.paddingBlockEnd, isDefaultMarginValue, BOX_SUGGESTION],
-      ['padding-inline-start', s.paddingInlineStart, isDefaultMarginValue, BOX_SUGGESTION],
-      ['padding-inline-end', s.paddingInlineEnd, isDefaultMarginValue, BOX_SUGGESTION],
+      ['padding-block-start', s.paddingBlockStart, isZeroPx, BOX_SUGGESTION],
+      ['padding-block-end', s.paddingBlockEnd, isZeroPx, BOX_SUGGESTION],
+      ['padding-inline-start', s.paddingInlineStart, isZeroPx, BOX_SUGGESTION],
+      ['padding-inline-end', s.paddingInlineEnd, isZeroPx, BOX_SUGGESTION],
       // Physical border-width (skip when logical counterpart is also non-default)
-      ['border-top-width', s.borderTopWidth, isDefaultMarginValue, BOX_SUGGESTION, skipBorderTop],
-      [
-        'border-right-width',
-        s.borderRightWidth,
-        isDefaultMarginValue,
-        BOX_SUGGESTION,
-        skipBorderRight,
-      ],
-      [
-        'border-bottom-width',
-        s.borderBottomWidth,
-        isDefaultMarginValue,
-        BOX_SUGGESTION,
-        skipBorderBottom,
-      ],
-      [
-        'border-left-width',
-        s.borderLeftWidth,
-        isDefaultMarginValue,
-        BOX_SUGGESTION,
-        skipBorderLeft,
-      ],
+      ['border-top-width', s.borderTopWidth, isZeroPx, BOX_SUGGESTION, skipBorderTop],
+      ['border-right-width', s.borderRightWidth, isZeroPx, BOX_SUGGESTION, skipBorderRight],
+      ['border-bottom-width', s.borderBottomWidth, isZeroPx, BOX_SUGGESTION, skipBorderBottom],
+      ['border-left-width', s.borderLeftWidth, isZeroPx, BOX_SUGGESTION, skipBorderLeft],
       // Logical border-width
-      ['border-block-start-width', s.borderBlockStartWidth, isDefaultMarginValue, BOX_SUGGESTION],
-      ['border-block-end-width', s.borderBlockEndWidth, isDefaultMarginValue, BOX_SUGGESTION],
-      ['border-inline-start-width', s.borderInlineStartWidth, isDefaultMarginValue, BOX_SUGGESTION],
-      ['border-inline-end-width', s.borderInlineEndWidth, isDefaultMarginValue, BOX_SUGGESTION],
+      ['border-block-start-width', s.borderBlockStartWidth, isZeroPx, BOX_SUGGESTION],
+      ['border-block-end-width', s.borderBlockEndWidth, isZeroPx, BOX_SUGGESTION],
+      ['border-inline-start-width', s.borderInlineStartWidth, isZeroPx, BOX_SUGGESTION],
+      ['border-inline-end-width', s.borderInlineEndWidth, isZeroPx, BOX_SUGGESTION],
       // Background
       ['background-color', s.backgroundColor, isDefaultBackgroundColor, BG_SUGGESTION],
       ['background-image', s.backgroundImage, isDefaultNoneValue, BG_SUGGESTION],

--- a/src/rules/context.ts
+++ b/src/rules/context.ts
@@ -77,7 +77,7 @@ export function isReplacedInlineElement(tagName: string): boolean {
   return REPLACED_INLINE_ELEMENTS.has(tagName);
 }
 
-export function isDefaultMarginValue(value: string): boolean {
+export function isZeroPx(value: string): boolean {
   return value === '0px';
 }
 

--- a/src/rules/inline-no-logical-vertical-margin.ts
+++ b/src/rules/inline-no-logical-vertical-margin.ts
@@ -1,5 +1,5 @@
 import { type RuleDescriptor, type Warning, createWarning } from './types.ts';
-import { isDefaultMarginValue, isReplacedInlineElement } from './context.ts';
+import { isZeroPx, isReplacedInlineElement } from './context.ts';
 import { registerRule } from './registry.ts';
 
 const RULE_ID = 'inline-no-logical-vertical-margin' as const;
@@ -19,7 +19,7 @@ const rule: RuleDescriptor = {
 
     const warnings: Warning[] = [];
 
-    if (!isDefaultMarginValue(marginBlockStart)) {
+    if (!isZeroPx(marginBlockStart)) {
       warnings.push(
         warn({
           property: 'margin-block-start',
@@ -31,7 +31,7 @@ const rule: RuleDescriptor = {
       );
     }
 
-    if (!isDefaultMarginValue(marginBlockEnd)) {
+    if (!isZeroPx(marginBlockEnd)) {
       warnings.push(
         warn({
           property: 'margin-block-end',

--- a/src/rules/inline-no-vertical-margin.ts
+++ b/src/rules/inline-no-vertical-margin.ts
@@ -1,5 +1,5 @@
 import { type RuleDescriptor, type Warning, createWarning } from './types.ts';
-import { isDefaultMarginValue, isReplacedInlineElement, isVerticalWritingMode } from './context.ts';
+import { isZeroPx, isReplacedInlineElement, isVerticalWritingMode } from './context.ts';
 import { registerRule } from './registry.ts';
 
 const RULE_ID = 'inline-no-vertical-margin' as const;
@@ -22,7 +22,7 @@ const rule: RuleDescriptor = {
 
     const warnings: Warning[] = [];
 
-    if (!isDefaultMarginValue(marginTop)) {
+    if (!isZeroPx(marginTop)) {
       warnings.push(
         warn({
           property: 'margin-top',
@@ -34,7 +34,7 @@ const rule: RuleDescriptor = {
       );
     }
 
-    if (!isDefaultMarginValue(marginBottom)) {
+    if (!isZeroPx(marginBottom)) {
       warnings.push(
         warn({
           property: 'margin-bottom',

--- a/src/rules/table-no-margin.ts
+++ b/src/rules/table-no-margin.ts
@@ -1,5 +1,5 @@
 import { type RuleDescriptor, type Warning, createWarning } from './types.ts';
-import { isDefaultMarginValue } from './context.ts';
+import { isZeroPx } from './context.ts';
 import { registerRule } from './registry.ts';
 
 const RULE_ID = 'table-no-margin' as const;
@@ -54,8 +54,8 @@ const rule: RuleDescriptor = {
     for (const [physical, logical, cssPhy, cssLog] of MARGIN_PROPERTIES) {
       const phyVal = s[physical];
       const logVal = s[logical];
-      const phyNonDefault = !isDefaultMarginValue(phyVal);
-      const logNonDefault = !isDefaultMarginValue(logVal);
+      const phyNonDefault = !isZeroPx(phyVal);
+      const logNonDefault = !isZeroPx(logVal);
 
       // Skip physical when logical is also set — both resolve to the same axis in getComputedStyle.
       if (phyNonDefault && !logNonDefault) {

--- a/src/rules/table-no-padding.ts
+++ b/src/rules/table-no-padding.ts
@@ -1,6 +1,6 @@
 import { type RuleDescriptor, type Warning, createWarning } from './types.ts';
 import { registerRule } from './registry.ts';
-import { isDefaultMarginValue } from './context.ts';
+import { isZeroPx } from './context.ts';
 
 const RULE_ID = 'table-no-padding' as const;
 
@@ -76,8 +76,8 @@ const rule: RuleDescriptor = {
     for (const { physical, logical } of PADDING_PAIRS) {
       const physicalValue = ctx.styles[physical.key];
       const logicalValue = ctx.styles[logical.key];
-      const physicalNonDefault = !isDefaultMarginValue(physicalValue);
-      const logicalNonDefault = !isDefaultMarginValue(logicalValue);
+      const physicalNonDefault = !isZeroPx(physicalValue);
+      const logicalNonDefault = !isZeroPx(logicalValue);
 
       // Physical: skip when logical counterpart is also non-default (prefer logical to avoid double-warnings)
       if (physicalNonDefault && !logicalNonDefault) {


### PR DESCRIPTION
## Summary

- Rename `isDefaultMarginValue` to `isZeroPx` in `src/rules/context.ts` and all 5 consumer files
- The function checks `value === '0px'` but was used for padding, border-width, and min-size defaults — not just margins. The new name is semantically accurate.
- Pure rename — no behavior change. All 964 tests pass.

Closes #174

## Test plan

- [x] `pnpm build` passes (no type errors)
- [x] `pnpm test` — 964 tests passing
- [x] `pnpm lint` — clean
- [x] `pnpm fmt:check` — clean
- [x] `grep -r isDefaultMarginValue src/` returns zero hits